### PR TITLE
Fix naming inconsistency for module definitions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.application)
@@ -38,10 +38,10 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.hilt)
     implementation(libs.splashscreen)
-    implementation(project(module.di))
-    implementation(project(module.domain.features))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.domain.settings))
-    implementation(project(module.presentation.home))
+    implementation(project(Modules.di))
+    implementation(project(Modules.domain.features))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.domain.settings))
+    implementation(project(Modules.presentation.home))
     ksp(libs.hilt.compiler)
 }

--- a/buildSrc/src/main/kotlin/com/sottti/roller/coasters/buildSrc/Modules.kt
+++ b/buildSrc/src/main/kotlin/com/sottti/roller/coasters/buildSrc/Modules.kt
@@ -2,8 +2,8 @@
 
 package com.sottti.roller.coasters.buildSrc
 
-object module {
-    object presentation {
+object Modules {
+    object Presentation {
         const val aboutMe = ":presentation:about-me"
         const val empty = ":presentation:empty"
         const val error = ":presentation:error"
@@ -23,7 +23,7 @@ object module {
         const val stringProvider = ":presentation:string-provider"
         const val topBars = ":presentation:top-bars"
 
-        object designSystem {
+        object DesignSystem {
             const val cardGrid = ":presentation:design-system:card-grid"
             const val chip = ":presentation:design-system:chip"
             const val colors = ":presentation:design-system:colors"
@@ -43,7 +43,7 @@ object module {
         }
     }
 
-    object domain {
+    object Domain {
         const val features = ":domain:features"
         const val fixtures = ":domain:fixtures"
         const val model = ":domain:model"
@@ -51,14 +51,14 @@ object module {
         const val settings = ":domain:settings"
     }
 
-    object data {
+    object Data {
         const val features = ":data:features"
         const val network = ":data:network"
         const val rollerCoasters = ":data:roller-coasters"
         const val settings = ":data:settings"
     }
 
-    object utils {
+    object Utils {
         const val timeDates = ":utils:time-dates"
     }
 

--- a/data/features/build.gradle.kts
+++ b/data/features/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -13,6 +13,6 @@ android {
 
 dependencies {
     implementation(libs.hilt)
-    implementation(project(module.domain.features))
+    implementation(project(Modules.domain.features))
     ksp(libs.hilt.compiler)
 }

--- a/data/roller-coasters/build.gradle.kts
+++ b/data/roller-coasters/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,10 +18,10 @@ dependencies {
     implementation(libs.room.paging)
     implementation(libs.startup.runtime)
     implementation(libs.work.runtime)
-    implementation(project(module.data.network))
-    implementation(project(module.domain.fixtures))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.utils.timeDates))
+    implementation(project(Modules.data.network))
+    implementation(project(Modules.domain.fixtures))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.utils.timeDates))
     ksp(libs.hilt.compiler)
     ksp(libs.room.compiler)
 

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,8 +18,8 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.datastore.preferences)
     implementation(libs.hilt)
-    implementation(project(module.domain.features))
-    implementation(project(module.domain.settings))
+    implementation(project(Modules.domain.features))
+    implementation(project(Modules.domain.settings))
     ksp(libs.hilt.compiler)
 
     androidTestImplementation(libs.junit.ext)

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -11,12 +11,12 @@ android {
 }
 
 dependencies {
-    api(project(module.domain.rollerCoasters))
+    api(project(Modules.domain.rollerCoasters))
     implementation(libs.hilt)
-    implementation(project(module.data.features))
-    implementation(project(module.data.rollerCoasters))
-    implementation(project(module.data.settings))
-    implementation(project(module.domain.features))
-    implementation(project(module.domain.settings))
+    implementation(project(Modules.data.features))
+    implementation(project(Modules.data.rollerCoasters))
+    implementation(project(Modules.data.settings))
+    implementation(project(Modules.domain.features))
+    implementation(project(Modules.domain.settings))
     ksp(libs.hilt.compiler)
 }

--- a/domain/fixtures/build.gradle.kts
+++ b/domain/fixtures/build.gradle.kts
@@ -1,9 +1,9 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
-    implementation(project(module.domain.rollerCoasters))
+    implementation(project(Modules.domain.rollerCoasters))
 }

--- a/domain/roller-coasters/build.gradle.kts
+++ b/domain/roller-coasters/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -6,8 +6,8 @@ plugins {
 
 dependencies {
     api(libs.result)
-    api(project(module.domain.model))
-    api(project(module.domain.settings))
+    api(project(Modules.domain.model))
+    api(project(Modules.domain.settings))
     implementation(libs.javax.inject)
     implementation(libs.kotlin.coroutines.core)
     implementation(libs.paging.common)
@@ -19,5 +19,5 @@ dependencies {
     testImplementation(libs.paging.common)
     testImplementation(libs.paging.testing)
     testImplementation(libs.truth)
-    testImplementation(project(module.domain.fixtures))
+    testImplementation(project(Modules.domain.fixtures))
 }

--- a/domain/settings/build.gradle.kts
+++ b/domain/settings/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
@@ -8,7 +8,7 @@ dependencies {
     implementation(libs.annotations)
     implementation(libs.javax.inject)
     implementation(libs.kotlin.coroutines.core)
-    implementation(project(module.domain.features))
+    implementation(project(Modules.domain.features))
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.coroutines.test)

--- a/presentation/about-me/build.gradle.kts
+++ b/presentation/about-me/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -22,18 +22,18 @@ dependencies {
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.cardGrid))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.heroImage))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.images))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.format))
-    implementation(project(module.presentation.navigationExternal))
-    implementation(project(module.presentation.previews))
-    implementation(project(module.presentation.topBars))
+    implementation(project(Modules.presentation.designSystem.cardGrid))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.heroImage))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.images))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.format))
+    implementation(project(Modules.presentation.navigationExternal))
+    implementation(project(Modules.presentation.previews))
+    implementation(project(Modules.presentation.topBars))
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/presentation/design-system/card-grid/build.gradle.kts
+++ b/presentation/design-system/card-grid/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,9 +18,9 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/chip/build.gradle.kts
+++ b/presentation/design-system/chip/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,11 +15,11 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.icons))
+    api(project(Modules.presentation.designSystem.icons))
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/colors/build.gradle.kts
+++ b/presentation/design-system/colors/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    api(project(module.domain.settings))
+    api(project(Modules.domain.settings))
     implementation(libs.compose.material)
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui)

--- a/presentation/design-system/dialogs/build.gradle.kts
+++ b/presentation/design-system/dialogs/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,12 +15,12 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.icons))
+    api(project(Modules.presentation.designSystem.icons))
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/hero-image/build.gradle.kts
+++ b/presentation/design-system/hero-image/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,11 +15,11 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.images))
+    api(project(Modules.presentation.designSystem.images))
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/icons/build.gradle.kts
+++ b/presentation/design-system/icons/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -19,8 +19,8 @@ dependencies {
     implementation(libs.compose.ui.tooling)
     implementation(libs.material)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/map/build.gradle.kts
+++ b/presentation/design-system/map/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,6 +18,6 @@ dependencies {
     implementation(libs.compose.maps)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.images))
-    implementation(project(module.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.designSystem.images))
+    implementation(project(Modules.presentation.designSystem.themes))
 }

--- a/presentation/design-system/progress-indicators/build.gradle.kts
+++ b/presentation/design-system/progress-indicators/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,7 +18,7 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/roller-coaster-card/build.gradle.kts
+++ b/presentation/design-system/roller-coaster-card/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,11 +18,11 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.imageLoading))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.imageLoading))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/switch/build.gradle.kts
+++ b/presentation/design-system/switch/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,6 +18,6 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/text/build.gradle.kts
+++ b/presentation/design-system/text/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -18,7 +18,7 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/design-system/themes/build.gradle.kts
+++ b/presentation/design-system/themes/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,13 +15,13 @@ android {
 
 dependencies {
     api(libs.compose.window.size)
-    api(project(module.presentation.designSystem.colors))
+    api(project(Modules.presentation.designSystem.colors))
     implementation(libs.compose.material)
     implementation(libs.material)
     implementation(libs.splashscreen)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.di))
-    implementation(project(module.domain.settings))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.typography))
+    implementation(project(Modules.di))
+    implementation(project(Modules.domain.settings))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.typography))
 }

--- a/presentation/empty/build.gradle.kts
+++ b/presentation/empty/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,15 +15,15 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.illustrations))
+    api(project(Modules.presentation.designSystem.illustrations))
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.informative))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.informative))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/error/build.gradle.kts
+++ b/presentation/error/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,15 +15,15 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.illustrations))
+    api(project(Modules.presentation.designSystem.illustrations))
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.informative))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.informative))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/explore/build.gradle.kts
+++ b/presentation/explore/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -16,7 +16,7 @@ android {
 }
 
 dependencies {
-    api(project(module.domain.rollerCoasters))
+    api(project(Modules.domain.rollerCoasters))
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
@@ -25,21 +25,21 @@ dependencies {
     implementation(libs.paging.compose)
     implementation(libs.paging.runtime)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.fixtures))
-    implementation(project(module.presentation.designSystem.chip))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.rollerCoasterCard))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.empty))
-    implementation(project(module.presentation.error))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.format))
-    implementation(project(module.presentation.imageLoading))
-    implementation(project(module.presentation.previews))
-    implementation(project(module.presentation.stringProvider))
-    implementation(project(module.presentation.topBars))
+    implementation(project(Modules.domain.fixtures))
+    implementation(project(Modules.presentation.designSystem.chip))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.rollerCoasterCard))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.empty))
+    implementation(project(Modules.presentation.error))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.format))
+    implementation(project(Modules.presentation.imageLoading))
+    implementation(project(Modules.presentation.previews))
+    implementation(project(Modules.presentation.stringProvider))
+    implementation(project(Modules.presentation.topBars))
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/presentation/favourites/build.gradle.kts
+++ b/presentation/favourites/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -24,17 +24,17 @@ dependencies {
     implementation(libs.paging.compose)
     implementation(libs.paging.runtime)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.fixtures))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.rollerCoasterCard))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.empty))
-    implementation(project(module.presentation.error))
-    implementation(project(module.presentation.previews))
-    implementation(project(module.presentation.topBars))
+    implementation(project(Modules.domain.fixtures))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.rollerCoasterCard))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.empty))
+    implementation(project(Modules.presentation.error))
+    implementation(project(Modules.presentation.previews))
+    implementation(project(Modules.presentation.topBars))
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/presentation/fixtures/build.gradle.kts
+++ b/presentation/fixtures/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -16,5 +16,5 @@ android {
 dependencies {
     implementation(libs.compose.foundation)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.model))
+    implementation(project(Modules.domain.model))
 }

--- a/presentation/format/build.gradle.kts
+++ b/presentation/format/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -22,10 +22,10 @@ dependencies {
     implementation(libs.compose.runtime)
     implementation(libs.hilt)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.fixtures))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.fixtures))
+    implementation(project(Modules.domain.fixtures))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.fixtures))
     ksp(libs.hilt.compiler)
 
     androidTestImplementation(libs.junit.ext)

--- a/presentation/home/build.gradle.kts
+++ b/presentation/home/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -22,15 +22,15 @@ dependencies {
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.aboutMe))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.explore))
-    implementation(project(module.presentation.favourites))
-    implementation(project(module.presentation.navigation))
-    implementation(project(module.presentation.rollerCoasterDetails))
-    implementation(project(module.presentation.search))
-    implementation(project(module.presentation.settings))
+    implementation(project(Modules.presentation.aboutMe))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.explore))
+    implementation(project(Modules.presentation.favourites))
+    implementation(project(Modules.presentation.navigation))
+    implementation(project(Modules.presentation.rollerCoasterDetails))
+    implementation(project(Modules.presentation.search))
+    implementation(project(Modules.presentation.settings))
     ksp(libs.hilt.compiler)
 }

--- a/presentation/image-loading/build.gradle.kts
+++ b/presentation/image-loading/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -14,14 +14,14 @@ android {
 }
 
 dependencies {
-    api(project(module.domain.model))
+    api(project(Modules.domain.model))
     implementation(libs.coil.compose)
     implementation(libs.coil.network.ktor3)
     implementation(libs.compose.material)
     implementation(libs.compose.ui.tooling)
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.previews))
     runtimeOnly(libs.startup.runtime)
 }

--- a/presentation/informative/build.gradle.kts
+++ b/presentation/informative/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -15,17 +15,17 @@ android {
 }
 
 dependencies {
-    api(project(module.presentation.designSystem.illustrations))
+    api(project(Modules.presentation.designSystem.illustrations))
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
     implementation(libs.compose.runtime)
     implementation(libs.compose.ui)
     implementation(libs.compose.ui.tooling)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.colors))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.fixtures))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.presentation.designSystem.colors))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.fixtures))
+    implementation(project(Modules.presentation.previews))
 }

--- a/presentation/roller-coaster-details/build.gradle.kts
+++ b/presentation/roller-coaster-details/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -21,19 +21,19 @@ dependencies {
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.fixtures))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.map))
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.error))
-    implementation(project(module.presentation.format))
-    implementation(project(module.presentation.imageLoading))
-    implementation(project(module.presentation.navigation))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.domain.fixtures))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.map))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.error))
+    implementation(project(Modules.presentation.format))
+    implementation(project(Modules.presentation.imageLoading))
+    implementation(project(Modules.presentation.navigation))
+    implementation(project(Modules.presentation.previews))
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/presentation/search/build.gradle.kts
+++ b/presentation/search/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -20,13 +20,13 @@ dependencies {
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.rollerCoasters))
-    implementation(project(module.presentation.designSystem.dimensions))
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.rollerCoasterCard))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.empty))
-    implementation(project(module.presentation.error))
-    implementation(project(module.presentation.topBars))
+    implementation(project(Modules.domain.rollerCoasters))
+    implementation(project(Modules.presentation.designSystem.dimensions))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.rollerCoasterCard))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.empty))
+    implementation(project(Modules.presentation.error))
+    implementation(project(Modules.presentation.topBars))
     ksp(libs.hilt.compiler)
 }

--- a/presentation/settings/build.gradle.kts
+++ b/presentation/settings/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -21,15 +21,15 @@ dependencies {
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.domain.features))
-    implementation(project(module.domain.settings))
-    implementation(project(module.presentation.designSystem.dialogs))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.progressIndicators))
-    implementation(project(module.presentation.designSystem.switch))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.designSystem.themes))
-    implementation(project(module.presentation.previews))
+    implementation(project(Modules.domain.features))
+    implementation(project(Modules.domain.settings))
+    implementation(project(Modules.presentation.designSystem.dialogs))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.progressIndicators))
+    implementation(project(Modules.presentation.designSystem.switch))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.designSystem.themes))
+    implementation(project(Modules.presentation.previews))
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/presentation/top-bars/build.gradle.kts
+++ b/presentation/top-bars/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.android.library)
@@ -17,7 +17,7 @@ dependencies {
     implementation(libs.compose.material)
     implementation(libs.compose.navigation)
     implementation(platform(libs.compose.bom))
-    implementation(project(module.presentation.designSystem.icons))
-    implementation(project(module.presentation.designSystem.text))
-    implementation(project(module.presentation.navigation))
+    implementation(project(Modules.presentation.designSystem.icons))
+    implementation(project(Modules.presentation.designSystem.text))
+    implementation(project(Modules.presentation.navigation))
 }

--- a/utils/time-dates/build.gradle.kts
+++ b/utils/time-dates/build.gradle.kts
@@ -1,11 +1,11 @@
-import com.sottti.roller.coasters.buildSrc.module
+import com.sottti.roller.coasters.buildSrc.Modules
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
 }
 
 dependencies {
-    api(project(module.domain.model))
+    api(project(Modules.domain.model))
     implementation(libs.annotations)
 
     testImplementation(libs.junit)


### PR DESCRIPTION
## Summary
- rename the `module` object to `Modules`
- update all build files to reference the new object

## Testing
- `./gradlew help --no-daemon`
- `./gradlew test --no-daemon` *(fails: Could not complete due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_687b60bb4494832ea7df9f1ac3085646