### PR TITLE
Implement search endpoint logic

### DIFF
--- a/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/RollerCoastersRemoteDataSource.kt
+++ b/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/RollerCoastersRemoteDataSource.kt
@@ -10,6 +10,7 @@ import com.sottti.roller.coasters.data.roller.coasters.datasources.remote.mapper
 import com.sottti.roller.coasters.domain.model.Result
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoaster
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoasterId
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
 import com.sottti.roller.coasters.domain.settings.model.measurementSystem.ResolvedMeasurementSystem
 import com.sottti.roller.coasters.domain.settings.model.measurementSystem.ResolvedMeasurementSystem.Metric
 import kotlinx.coroutines.Dispatchers
@@ -32,6 +33,19 @@ internal class RollerCoastersRemoteDataSource @Inject constructor(
             .getRollerCoaster(id)
             .mapBoth(
                 success = { rollerCoaster -> Ok(rollerCoaster.toDomain(measurementSystem)) },
+                failure = { exception -> Err(exception) },
+            )
+
+    suspend fun searchRollerCoasters(
+        query: SearchQuery,
+        measurementSystem: ResolvedMeasurementSystem,
+    ): Result<List<RollerCoaster>> =
+        api
+            .searchRollerCoasters(query)
+            .mapBoth(
+                success = { search ->
+                    Ok(search.coasters.map { it.toDomain(measurementSystem) })
+                },
                 failure = { exception -> Err(exception) },
             )
 

--- a/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/api/RollerCoastersApiCalls.kt
+++ b/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/api/RollerCoastersApiCalls.kt
@@ -5,7 +5,9 @@ import com.sottti.roller.coasters.data.network.model.ResultApiModel
 import com.sottti.roller.coasters.data.network.safeApiCall
 import com.sottti.roller.coasters.data.roller.coasters.datasources.remote.model.RollerCoasterApiModel
 import com.sottti.roller.coasters.data.roller.coasters.datasources.remote.model.RollerCoastersApiModel
+import com.sottti.roller.coasters.data.roller.coasters.datasources.remote.model.SearchCoastersApiModel
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoasterId
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
 import io.ktor.client.HttpClient
 import javax.inject.Inject
 
@@ -22,4 +24,9 @@ internal class RollerCoastersApiCalls @Inject constructor(
         id: RollerCoasterId,
     ): ResultApiModel<RollerCoasterApiModel> =
         safeApiCall { httpClient.fetch("$API_BASE_URL/${id.value}") }
+
+    suspend fun searchRollerCoasters(
+        query: SearchQuery,
+    ): ResultApiModel<SearchCoastersApiModel> =
+        safeApiCall { httpClient.fetch("$API_BASE_URL/search?q=${query.value}") }
 }

--- a/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/model/SearchCoastersApiModel.kt
+++ b/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/remote/model/SearchCoastersApiModel.kt
@@ -1,0 +1,10 @@
+package com.sottti.roller.coasters.data.roller.coasters.datasources.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+internal data class SearchCoastersApiModel(
+    @SerialName("coasters") val coasters: List<RollerCoasterApiModel>,
+    @SerialName("totalMatch") val totalMatch: Int,
+)

--- a/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/repository/RollerCoastersRepositoryImpl.kt
+++ b/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/repository/RollerCoastersRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.sottti.roller.coasters.data.roller.coasters.sync.RollerCoasterSyncSch
 import com.sottti.roller.coasters.domain.model.Result
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoaster
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoasterId
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
 import com.sottti.roller.coasters.domain.roller.coasters.model.SortByFilter
 import com.sottti.roller.coasters.domain.roller.coasters.model.TypeFilter
 import com.sottti.roller.coasters.domain.roller.coasters.repository.RollerCoastersRepository
@@ -97,4 +98,11 @@ internal class RollerCoastersRepositoryImpl @Inject constructor(
             measurementSystem = measurementSystem,
             pagerConfig = pagerConfig,
         )
+
+    override suspend fun searchRollerCoasters(
+        query: SearchQuery,
+        measurementSystem: ResolvedMeasurementSystem,
+    ): Result<List<RollerCoaster>> =
+        remoteDataSource.searchRollerCoasters(query, measurementSystem)
+            .onSuccess { localDataSource.storeRollerCoasters(it) }
 }

--- a/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/model/SearchQuery.kt
+++ b/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/model/SearchQuery.kt
@@ -1,0 +1,4 @@
+package com.sottti.roller.coasters.domain.roller.coasters.model
+
+@JvmInline
+public value class SearchQuery(public val value: String)

--- a/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/repository/RollerCoastersRepository.kt
+++ b/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/repository/RollerCoastersRepository.kt
@@ -4,6 +4,7 @@ import androidx.paging.PagingData
 import com.sottti.roller.coasters.domain.model.Result
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoaster
 import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoasterId
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
 import com.sottti.roller.coasters.domain.roller.coasters.model.SortByFilter
 import com.sottti.roller.coasters.domain.roller.coasters.model.TypeFilter
 import com.sottti.roller.coasters.domain.settings.model.measurementSystem.ResolvedMeasurementSystem
@@ -36,4 +37,9 @@ public interface RollerCoastersRepository {
     public fun observeFavouriteRollerCoasters(
         measurementSystem: ResolvedMeasurementSystem,
     ): Flow<PagingData<RollerCoaster>>
+
+    public suspend fun searchRollerCoasters(
+        query: SearchQuery,
+        measurementSystem: ResolvedMeasurementSystem,
+    ): Result<List<RollerCoaster>>
 }

--- a/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/usecase/SearchRollerCoasters.kt
+++ b/domain/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/domain/roller/coasters/usecase/SearchRollerCoasters.kt
@@ -1,0 +1,22 @@
+package com.sottti.roller.coasters.domain.roller.coasters.usecase
+
+import com.sottti.roller.coasters.domain.roller.coasters.model.RollerCoaster
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
+import com.sottti.roller.coasters.domain.roller.coasters.repository.RollerCoastersRepository
+import com.sottti.roller.coasters.domain.settings.mapper.toResolvedMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.usecase.measurementSystem.GetAppMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.usecase.measurementSystem.GetSystemMeasurementSystem
+import com.sottti.roller.coasters.domain.model.Result
+import javax.inject.Inject
+
+public class SearchRollerCoasters @Inject constructor(
+    private val getAppMeasurementSystem: GetAppMeasurementSystem,
+    private val getSystemMeasurementSystem: GetSystemMeasurementSystem,
+    private val rollerCoastersRepository: RollerCoastersRepository,
+) {
+    public suspend operator fun invoke(query: SearchQuery): Result<List<RollerCoaster>> {
+        val measurementSystem = getAppMeasurementSystem()
+            .toResolvedMeasurementSystem { getSystemMeasurementSystem() }
+        return rollerCoastersRepository.searchRollerCoasters(query, measurementSystem)
+    }
+}

--- a/domain/roller-coasters/src/test/kotlin/com/sottti/roller/coasters/domain/roller/coasters/usecase/SearchRollerCoastersTest.kt
+++ b/domain/roller-coasters/src/test/kotlin/com/sottti/roller/coasters/domain/roller/coasters/usecase/SearchRollerCoastersTest.kt
@@ -1,0 +1,79 @@
+package com.sottti.roller.coasters.domain.roller.coasters.usecase
+
+import com.github.michaelbull.result.Ok
+import com.google.common.truth.Truth.assertThat
+import com.sottti.roller.coasters.domain.fixtures.rollerCoaster
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
+import com.sottti.roller.coasters.domain.roller.coasters.repository.RollerCoastersRepository
+import com.sottti.roller.coasters.domain.settings.model.measurementSystem.AppMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.model.measurementSystem.ResolvedMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.model.measurementSystem.ResolvedMeasurementSystem.*
+import com.sottti.roller.coasters.domain.settings.model.measurementSystem.SystemMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.usecase.measurementSystem.GetAppMeasurementSystem
+import com.sottti.roller.coasters.domain.settings.usecase.measurementSystem.GetSystemMeasurementSystem
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+
+class SearchRollerCoastersTest {
+
+    private lateinit var getAppMeasurementSystem: GetAppMeasurementSystem
+    private lateinit var getSystemMeasurementSystem: GetSystemMeasurementSystem
+    private lateinit var repository: RollerCoastersRepository
+    private lateinit var searchRollerCoasters: SearchRollerCoasters
+
+    @Before
+    fun setUp() {
+        getAppMeasurementSystem = mockk()
+        getSystemMeasurementSystem = mockk()
+        repository = mockk()
+        searchRollerCoasters = SearchRollerCoasters(
+            getAppMeasurementSystem = getAppMeasurementSystem,
+            getSystemMeasurementSystem = getSystemMeasurementSystem,
+            rollerCoastersRepository = repository,
+        )
+    }
+
+    @Test
+    fun `uses metric when app metric`() = runTest {
+        val query = SearchQuery("test")
+        val expected = listOf(rollerCoaster(Metric))
+        coEvery { getAppMeasurementSystem() } returns AppMeasurementSystem.Metric
+        coEvery { repository.searchRollerCoasters(query, Metric) } returns Ok(expected)
+
+        val result = searchRollerCoasters(query)
+
+        assertThat(result).isEqualTo(Ok(expected))
+        coVerify { repository.searchRollerCoasters(query, Metric) }
+    }
+
+    @Test
+    fun `uses imperial uk when app imperial uk`() = runTest {
+        val query = SearchQuery("test")
+        val expected = listOf(rollerCoaster(ImperialUk))
+        coEvery { getAppMeasurementSystem() } returns AppMeasurementSystem.ImperialUk
+        coEvery { repository.searchRollerCoasters(query, ImperialUk) } returns Ok(expected)
+
+        val result = searchRollerCoasters(query)
+
+        assertThat(result).isEqualTo(Ok(expected))
+        coVerify { repository.searchRollerCoasters(query, ImperialUk) }
+    }
+
+    @Test
+    fun `uses resolved system when app system`() = runTest {
+        val query = SearchQuery("test")
+        val expected = listOf(rollerCoaster(ImperialUs))
+        coEvery { getAppMeasurementSystem() } returns AppMeasurementSystem.System
+        coEvery { getSystemMeasurementSystem() } returns SystemMeasurementSystem.ImperialUs
+        coEvery { repository.searchRollerCoasters(query, ImperialUs) } returns Ok(expected)
+
+        val result = searchRollerCoasters(query)
+
+        assertThat(result).isEqualTo(Ok(expected))
+        coVerify { repository.searchRollerCoasters(query, ImperialUs) }
+    }
+}


### PR DESCRIPTION
## Summary
- support search queries in domain and data layers
- add API call and model for `/search` endpoint
- implement repository and use case for search
- add unit tests verifying measurement system handling
- introduce `SearchQuery` type

## Testing
- `./gradlew test` *(fails: SDK not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b5e1079f0832eae6b91575b232c9b