### PR TITLE
Add basic search feature UI

### DIFF
--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/data/SearchViewModel.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/data/SearchViewModel.kt
@@ -1,11 +1,15 @@
 package com.sottti.roller.coasters.presentation.search.data
 
 import androidx.lifecycle.ViewModel
-import com.sottti.roller.coasters.domain.roller.coasters.usecase.ObserveFavouriteRollerCoasters
+import androidx.lifecycle.viewModelScope
+import com.sottti.roller.coasters.domain.roller.coasters.model.SearchQuery
+import com.sottti.roller.coasters.domain.roller.coasters.usecase.SearchRollerCoasters
+import com.sottti.roller.coasters.presentation.search.model.SearchResult
 import com.sottti.roller.coasters.presentation.search.model.SearchAction
 import com.sottti.roller.coasters.presentation.search.model.SearchBarState
 import com.sottti.roller.coasters.presentation.search.model.SearchState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -13,15 +17,42 @@ import javax.inject.Inject
 
 @HiltViewModel
 internal class SearchViewModel @Inject constructor(
-    observeFavouriteRollerCoasters: ObserveFavouriteRollerCoasters,
+    private val searchRollerCoasters: SearchRollerCoasters,
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(SearchState(SearchBarState("Hint")))
+    private val _state = MutableStateFlow(SearchState(SearchBarState("")))
     val state: StateFlow<SearchState> = _state.asStateFlow()
 
     internal val onAction: (SearchAction) -> Unit = { action -> processAction(action) }
 
     private fun processAction(action: SearchAction) {
+        when (action) {
+            is SearchAction.QueryChanged -> {
+                _state.value = _state.value.copy(
+                    searchBar = _state.value.searchBar.copy(query = action.query)
+                )
+            }
+            SearchAction.SubmitQuery -> submitQuery()
+        }
+    }
 
+    private fun submitQuery() {
+        val query = _state.value.searchBar.query.trim()
+        if (query.isEmpty()) return
+
+        _state.value = _state.value.copy(isLoading = true)
+        viewModelScope.launch {
+            val result = searchRollerCoasters(SearchQuery(query))
+            val results = result.getOrElse { emptyList() }
+                .map { coaster ->
+                    SearchResult(
+                        id = coaster.id.value,
+                        imageUrl = coaster.pictures.main?.url,
+                        name = coaster.name.current.value,
+                        parkName = coaster.park.name.value,
+                    )
+                }
+            _state.value = _state.value.copy(isLoading = false, results = results)
+        }
     }
 }

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchAction.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchAction.kt
@@ -1,5 +1,6 @@
 package com.sottti.roller.coasters.presentation.search.model
 
 internal sealed interface SearchAction {
-
+    data class QueryChanged(val query: String) : SearchAction
+    data object SubmitQuery : SearchAction
 }

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchState.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchState.kt
@@ -2,8 +2,11 @@ package com.sottti.roller.coasters.presentation.search.model
 
 internal data class SearchState(
     val searchBar: SearchBarState,
+    val isLoading: Boolean = false,
+    val results: List<SearchResult> = emptyList(),
 )
 
 internal data class SearchBarState(
-    val hing: String,
+    val hint: String,
+    val query: String = "",
 )

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchResults.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchResults.kt
@@ -1,9 +1,19 @@
 package com.sottti.roller.coasters.presentation.search.ui
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.nestedScroll
+import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
+import com.sottti.roller.coasters.presentation.design.system.roller.coaster.card.RollerCoasterCard
 import com.sottti.roller.coasters.presentation.search.model.SearchAction
 import com.sottti.roller.coasters.presentation.search.model.SearchResult
 
@@ -14,7 +24,29 @@ internal fun SearchResults(
     onAction: (SearchAction) -> Unit,
     onNavigateToRollerCoaster: (Int) -> Unit,
     paddingValues: PaddingValues,
-    results: SearchResult,
+    results: List<SearchResult>,
 ) {
-
+    Column(
+        modifier = Modifier
+            .padding(paddingValues)
+            .fillMaxSize()
+    ) {
+        LazyColumn(
+            state = listState,
+            contentPadding = PaddingValues(dimensions.padding.medium),
+            verticalArrangement = Arrangement.spacedBy(dimensions.padding.medium),
+            modifier = Modifier
+                .fillMaxSize()
+                .nestedScroll(nestedScrollConnection)
+        ) {
+            items(results) { result ->
+                RollerCoasterCard.Small(
+                    imageUrl = result.imageUrl,
+                    parkName = result.parkName,
+                    rollerCoasterName = result.name,
+                    onClick = { onNavigateToRollerCoaster(result.id) },
+                )
+            }
+        }
+    }
 }

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUi.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUi.kt
@@ -2,14 +2,19 @@ package com.sottti.roller.coasters.presentation.search.ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SearchBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.sottti.roller.coasters.presentation.search.data.SearchViewModel
 import com.sottti.roller.coasters.presentation.search.model.SearchAction
+import com.sottti.roller.coasters.presentation.search.model.SearchState
 import com.sottti.roller.coasters.presentation.top.bars.MainTopBar
 
 @Composable
@@ -35,7 +40,9 @@ private fun SearchUi(
     onScrollToTop: (() -> Unit) -> Unit,
     viewModel: SearchViewModel,
 ) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
     SearchUi(
+        state = state,
         onAction = viewModel.onAction,
         onNavigateToRollerCoaster = onNavigateToRollerCoaster,
         onNavigateToSettings = onNavigateToSettings,
@@ -45,11 +52,14 @@ private fun SearchUi(
 @Composable
 @OptIn(ExperimentalMaterial3Api::class)
 internal fun SearchUi(
+    state: SearchState,
     onAction: (SearchAction) -> Unit,
     onNavigateToRollerCoaster: (Int) -> Unit,
     onNavigateToSettings: () -> Unit,
 ) {
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
+
+    val listState = rememberLazyListState()
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
@@ -60,5 +70,24 @@ internal fun SearchUi(
             )
         },
     ) { paddingValues ->
+        androidx.compose.foundation.layout.Column {
+            SearchBar(
+                query = state.searchBar.query,
+                onQueryChange = { onAction(SearchAction.QueryChanged(it)) },
+                onSearch = { onAction(SearchAction.SubmitQuery) },
+                active = false,
+                onActiveChange = {},
+                placeholder = { androidx.compose.material3.Text(state.searchBar.hint) }
+            )
+
+            SearchResults(
+                listState = listState,
+                nestedScrollConnection = scrollBehavior.nestedScrollConnection,
+                onAction = onAction,
+                onNavigateToRollerCoaster = onNavigateToRollerCoaster,
+                paddingValues = paddingValues,
+                results = state.results,
+            )
+        }
     }
 }

--- a/presentation/search/src/main/res/values-es-rES/strings.xml
+++ b/presentation/search/src/main/res/values-es-rES/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="top_bar_title">Favoritos</string>>
+    <string name="top_bar_title">Buscar</string>
+    <string name="search_hint">Buscar…</string>
 </resources>

--- a/presentation/search/src/main/res/values-gl/strings.xml
+++ b/presentation/search/src/main/res/values-gl/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="top_bar_title">Favoritos</string>>
+    <string name="top_bar_title">Buscar</string>
+    <string name="search_hint">Buscar…</string>
 </resources>

--- a/presentation/search/src/main/res/values/strings.xml
+++ b/presentation/search/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
-    <string name="top_bar_title">Search</string>>
+    <string name="top_bar_title">Search</string>
+    <string name="search_hint">Search…</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement simple SearchViewModel
- define SearchAction and SearchState
- build Search results list with Compose
- add strings for search hint and update translations

## Testing
- `./gradlew :presentation:search:test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_687f7ac1dfa0832eb48a939fc1bf0d0c