### PR TITLE
Add Search previews and screenshot tests

### DIFF
--- a/presentation/search/build.gradle.kts
+++ b/presentation/search/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
+    alias(libs.plugins.paparazzi)
 }
 
 android {
@@ -17,6 +18,7 @@ android {
 dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
+    implementation(libs.compose.ui.tooling)
     implementation(libs.hilt)
     implementation(libs.hilt.navigation.compose)
     implementation(platform(libs.compose.bom))
@@ -26,6 +28,8 @@ dependencies {
     implementation(project(module.presentation.designSystem.progressIndicators))
     implementation(project(module.presentation.designSystem.rollerCoasterCard))
     implementation(project(module.presentation.designSystem.text))
+    implementation(project(module.presentation.designSystem.themes))
+    implementation(project(module.presentation.previews))
     implementation(project(module.presentation.empty))
     implementation(project(module.presentation.error))
     implementation(project(module.presentation.topBars))

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchPreviewState.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/model/SearchPreviewState.kt
@@ -1,0 +1,13 @@
+package com.sottti.roller.coasters.presentation.search.model
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Immutable
+
+@Immutable
+internal data class SearchPreviewState(
+    val onAction: (SearchAction) -> Unit,
+    val onNavigateToRollerCoaster: (Int) -> Unit,
+    val onNavigateToSettings: () -> Unit,
+    val paddingValues: PaddingValues,
+    val state: SearchViewState,
+)

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiPreview.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiPreview.kt
@@ -1,0 +1,25 @@
+package com.sottti.roller.coasters.presentation.search.ui
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import com.sottti.roller.coasters.presentation.design.system.themes.RollerCoastersPreviewTheme
+import com.sottti.roller.coasters.presentation.previews.RollerCoastersPreview
+import com.sottti.roller.coasters.presentation.search.model.SearchPreviewState
+
+@Composable
+@RollerCoastersPreview
+@OptIn(ExperimentalMaterial3Api::class)
+internal fun SearchUiPreview(
+    @PreviewParameter(SearchUiStateProvider::class) state: SearchPreviewState,
+) {
+    RollerCoastersPreviewTheme {
+        SearchUi(
+            onAction = state.onAction,
+            onNavigateToRollerCoaster = state.onNavigateToRollerCoaster,
+            onNavigateToSettings = state.onNavigateToSettings,
+            paddingValues = state.paddingValues,
+            state = state.state,
+        )
+    }
+}

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiStateProvider.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiStateProvider.kt
@@ -1,0 +1,71 @@
+package com.sottti.roller.coasters.presentation.search.ui
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.sottti.roller.coasters.domain.fixtures.rollerCoaster
+import com.sottti.roller.coasters.domain.fixtures.anotherRollerCoaster
+import com.sottti.roller.coasters.presentation.search.model.SearchAction
+import com.sottti.roller.coasters.presentation.search.model.SearchBarViewState
+import com.sottti.roller.coasters.presentation.search.model.SearchPreviewState
+import com.sottti.roller.coasters.presentation.search.model.SearchResultViewState
+import com.sottti.roller.coasters.presentation.search.model.SearchViewState
+import com.sottti.roller.coasters.presentation.search.model.toViewState
+
+internal class SearchUiStateProvider : PreviewParameterProvider<SearchPreviewState> {
+    override val values: Sequence<SearchPreviewState> = sequenceOf(
+        idleState,
+        resultsState,
+        loadingState,
+    )
+}
+
+private val idleState = SearchPreviewState(
+    onAction = {},
+    onNavigateToRollerCoaster = {},
+    onNavigateToSettings = {},
+    paddingValues = PaddingValues(),
+    state = SearchViewState(
+        searchBar = SearchBarViewState(
+            hint = com.sottti.roller.coasters.presentation.search.R.string.search_hint,
+            query = null,
+            showClearIcon = false,
+        ),
+        loading = false,
+        results = emptyList(),
+    ),
+)
+
+private val resultsState = SearchPreviewState(
+    onAction = {},
+    onNavigateToRollerCoaster = {},
+    onNavigateToSettings = {},
+    paddingValues = PaddingValues(),
+    state = SearchViewState(
+        searchBar = SearchBarViewState(
+            hint = com.sottti.roller.coasters.presentation.search.R.string.search_hint,
+            query = "Dragon",
+            showClearIcon = true,
+        ),
+        loading = false,
+        results = listOf(
+            rollerCoaster().toViewState(),
+            anotherRollerCoaster().toViewState(),
+        ),
+    ),
+)
+
+private val loadingState = SearchPreviewState(
+    onAction = {},
+    onNavigateToRollerCoaster = {},
+    onNavigateToSettings = {},
+    paddingValues = PaddingValues(),
+    state = SearchViewState(
+        searchBar = SearchBarViewState(
+            hint = com.sottti.roller.coasters.presentation.search.R.string.search_hint,
+            query = "Dr",
+            showClearIcon = true,
+        ),
+        loading = true,
+        results = emptyList(),
+    ),
+)

--- a/presentation/search/src/test/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiSnapshotTest.kt
+++ b/presentation/search/src/test/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiSnapshotTest.kt
@@ -1,0 +1,46 @@
+package com.sottti.roller.coasters.presentation.search.ui
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.android.resources.NightMode
+import com.sottti.roller.coasters.presentation.search.model.SearchPreviewState
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class SearchUiSnapshotTest(
+    nightMode: NightMode,
+    private val state: SearchPreviewState,
+) {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
+        showSystemUi = false,
+        theme = "Theme.RollerCoasters",
+    )
+
+    @Test
+    fun snapshotTest() {
+        paparazzi.snapshot {
+            SearchUiPreview(state)
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> =
+            SearchUiStateProvider()
+                .values
+                .flatMap { state ->
+                    listOf(
+                        arrayOf(NightMode.NOTNIGHT, state),
+                        arrayOf(NightMode.NIGHT, state),
+                    )
+                }
+                .toList()
+    }
+}


### PR DESCRIPTION
## Summary
- add SearchPreviewState data model
- create SearchUiStateProvider with fixture data
- add SearchUiPreview composable
- add Paparazzi screenshot test for Search
- enable Paparazzi plugin and preview deps in Search build file

## Testing
- `./gradlew help` *(fails: The file 'local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6880add274fc832e98c4cf9e6a4d2514