### PR TITLE
Fix navigation bar state on back navigation

### DIFF
--- a/presentation/home/src/main/kotlin/com/sottti/roller/coasters/presentation/home/ui/HomeNavigationBar.kt
+++ b/presentation/home/src/main/kotlin/com/sottti/roller/coasters/presentation/home/ui/HomeNavigationBar.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -21,6 +22,7 @@ import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.sottti.roller.coasters.presentation.about.me.ui.AboutMeUi
 import com.sottti.roller.coasters.presentation.explore.ui.ExploreUi
@@ -54,6 +56,15 @@ internal fun NavigationBar(
     val state by viewModel.state.collectAsStateWithLifecycle()
     var selectedTab by rememberSaveable(stateSaver = NavigationDestination.saver) {
         mutableStateOf(startDestination)
+    }
+
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    LaunchedEffect(navBackStackEntry?.destination?.route) {
+        val destination = navBackStackEntry?.destination?.route?.toNavigationDestination()
+        if (destination != null && destination != selectedTab) {
+            selectedTab = destination
+            viewModel.actions.onDestinationSelected(destination)
+        }
     }
 
     val scrollToTopCallbacks = remember { mutableMapOf<NavigationDestination, () -> Unit>() }
@@ -155,4 +166,12 @@ private fun NavHostController.navigateTo(
         launchSingleTop = true
         restoreState = true
     }
+}
+
+private fun String.toNavigationDestination(): NavigationDestination? = when (this) {
+    AboutMe::class.simpleName -> AboutMe
+    Explore::class.simpleName -> Explore
+    Favourites::class.simpleName -> Favourites
+    Search::class.simpleName -> Search
+    else -> null
 }


### PR DESCRIPTION
## Summary
- update navigation bar state when the back stack entry changes
- map routes to `NavigationDestination` to keep selection in sync

## Testing
- `./gradlew test --no-daemon` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6880af32d530832eabcd39872c3735da