### PR TITLE
Improve Kotlin idioms

### DIFF
--- a/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/local/mapper/RollerCoastersRoomQueriesMapper.kt
+++ b/data/roller-coasters/src/main/kotlin/com/sottti/roller/coasters/data/roller/coasters/datasources/local/mapper/RollerCoastersRoomQueriesMapper.kt
@@ -22,26 +22,28 @@ internal fun createFilteredRollerCoastersQuery(
     sortByFilter: SortByFilter,
     typeFilter: TypeFilter,
 ): SimpleSQLiteQuery {
-    val args = mutableListOf<Any>()
-    val query = StringBuilder("SELECT * FROM $TABLE_ROLLER_COASTERS")
-
-    if (typeFilter != TypeFilter.All) {
-        query.append(" WHERE LOWER($COL_TYPE) = ?")
-        args += typeFilter.toSqlValue()
+    val args = buildList {
+        if (typeFilter != TypeFilter.All) add(typeFilter.toSqlValue())
+        add(limit)
+        add(offset)
     }
 
-    val direction = if (sortByFilter == SortByFilter.Alphabetical) "ASC" else "DESC"
+    val query = buildString {
+        append("SELECT * FROM $TABLE_ROLLER_COASTERS")
+        if (typeFilter != TypeFilter.All) {
+            append(" WHERE LOWER($COL_TYPE) = ?")
+        }
 
-    query.append(" ORDER BY ")
-        .append(sortByFilter.toSqlValue())
-        .append(" $direction, ")
-        .append("$COL_OPENED_DATE ASC, $COL_NAME_CURRENT ASC ")
-        .append("LIMIT ? OFFSET ?")
+        val direction = if (sortByFilter == SortByFilter.Alphabetical) "ASC" else "DESC"
 
-    args += limit
-    args += offset
+        append(" ORDER BY ")
+        append(sortByFilter.toSqlValue())
+        append(" $direction, ")
+        append("$COL_OPENED_DATE ASC, $COL_NAME_CURRENT ASC ")
+        append("LIMIT ? OFFSET ?")
+    }
 
-    return SimpleSQLiteQuery(query.toString(), args.toTypedArray())
+    return SimpleSQLiteQuery(query, args.toTypedArray())
 }
 
 private fun SortByFilter.toSqlValue(): String =

--- a/presentation/format/src/main/kotlin/com/sottti/roller/coasters/presentation/format/DisplayUnitFormatter.kt
+++ b/presentation/format/src/main/kotlin/com/sottti/roller/coasters/presentation/format/DisplayUnitFormatter.kt
@@ -91,23 +91,24 @@ public class DisplayUnitFormatter @Inject constructor(
     private fun Duration.toDisplayFormatGForce(
         defaultLocale: Locale,
     ): String {
-        val measures = mutableListOf<Measure>()
+        val measures = buildList {
+            var remaining = seconds.value.toLong()
 
-        var remaining = seconds.value.toLong()
-        val hours = remaining / 3600
-        if (hours > 0) {
-            measures.add(Measure(hours, MeasureUnit.HOUR))
-            remaining %= 3600
-        }
+            val hours = remaining / 3600
+            if (hours > 0) {
+                add(Measure(hours, MeasureUnit.HOUR))
+                remaining %= 3600
+            }
 
-        val minutes = remaining / 60
-        if (minutes > 0) {
-            measures.add(Measure(minutes, MeasureUnit.MINUTE))
-            remaining %= 60
-        }
+            val minutes = remaining / 60
+            if (minutes > 0) {
+                add(Measure(minutes, MeasureUnit.MINUTE))
+                remaining %= 60
+            }
 
-        if (remaining > 0 || measures.isEmpty()) {
-            measures.add(Measure(remaining, MeasureUnit.SECOND))
+            if (remaining > 0 || isEmpty()) {
+                add(Measure(remaining, MeasureUnit.SECOND))
+            }
         }
 
         val formatter = MeasureFormat.getInstance(defaultLocale, MeasureFormat.FormatWidth.SHORT)


### PR DESCRIPTION
## Summary
- adopt buildList DSL in DisplayUnitFormatter
- use buildList/buildString in RollerCoastersRoomQueriesMapper

## Testing
- `./gradlew test --no-daemon` *(fails: local.properties missing)*

------
https://chatgpt.com/codex/tasks/task_e_6880bc9638ec832e8994f90a85298e71