### PR TITLE
Fix time parser whitespace handling

### DIFF
--- a/utils/time-dates/src/main/kotlin/com/sottti/roller/coasters/utils/time/dates/mapper/TimeMapper.kt
+++ b/utils/time-dates/src/main/kotlin/com/sottti/roller/coasters/utils/time/dates/mapper/TimeMapper.kt
@@ -11,9 +11,10 @@ internal const val NEGATIVE_TIME_MESSAGE = "Minutes and seconds must be non-nega
 
 public fun String.toSeconds(): Int {
     val parts = trim().split(":")
-    if (parts.size != 2)
+    if (parts.size != 2) {
         throw IllegalArgumentException(INVALID_TIME_FORMAT_MESSAGE)
-    val (minutes, seconds) = parts.map { it.toInt() }
+    }
+    val (minutes, seconds) = parts.map { it.trim().toInt() }
     if (minutes < 0 || seconds < 0)
         throw IllegalArgumentException(NEGATIVE_TIME_MESSAGE)
     return (minutes * 60) + seconds


### PR DESCRIPTION
## Summary
- handle spaces around the colon in time strings

## Testing
- `./gradlew :utils:time-dates:test`

------
https://chatgpt.com/codex/tasks/task_e_6880c075c2c0832e8dc9d9ae440ac821