### PR TITLE
Fix naming inconsistency in settings module

### DIFF
--- a/data/settings/src/main/kotlin/com/sottti/roller/coasters/data/settings/datasource/SettingsLocalDataSource.kt
+++ b/data/settings/src/main/kotlin/com/sottti/roller/coasters/data/settings/datasource/SettingsLocalDataSource.kt
@@ -90,9 +90,9 @@ internal class SettingsLocalDataSource @Inject constructor(
         }
     }
 
-    suspend fun getAppColorContrast(): AppColorContrast = appAppColorContrastFlow.first()
+    suspend fun getAppColorContrast(): AppColorContrast = appColorContrastFlow.first()
 
-    fun observeAppColorContrast(): Flow<AppColorContrast> = appAppColorContrastFlow
+    fun observeAppColorContrast(): Flow<AppColorContrast> = appColorContrastFlow
 
     fun getSystemColorContrast(): SystemColorContrast =
         systemColorContrastManager.systemColorContrast
@@ -148,7 +148,7 @@ internal class SettingsLocalDataSource @Inject constructor(
             key.toTheme()
         }
 
-    private val appAppColorContrastFlow: Flow<AppColorContrast> =
+    private val appColorContrastFlow: Flow<AppColorContrast> =
         dataStore.data.map { preferences ->
             val key = preferences[appColorContrastKey] ?: appColorContrastDefaultValue
             key.toAppColorContrast()


### PR DESCRIPTION
## Summary
- rename `appAppColorContrastFlow` to `appColorContrastFlow`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c10b0858832ebaef82f66d26c8d1