### PR TITLE
Fix hero image namespace

### DIFF
--- a/presentation/design-system/hero-image/build.gradle.kts
+++ b/presentation/design-system/hero-image/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 android {
-    namespace = "com.sottti.roller.coasters.presentation.design.system.profile.picture"
+    namespace = "com.sottti.roller.coasters.presentation.design.system.hero.image"
     buildFeatures { compose = true }
     @Suppress("UnstableApiUsage")
     composeOptions { kotlinCompilerExtensionVersion = kotlinCompilerExtensionVersion }


### PR DESCRIPTION
## Summary
- adjust hero-image module namespace to match package structure
- attempted running Gradle tasks but build failed due to missing `local.properties`

## Testing
- `./gradlew :presentation:design-system:hero-image:tasks --no-daemon` *(fails: could not find `local.properties`)*

------
https://chatgpt.com/codex/tasks/task_e_6883755d84e0832e9f9efdb5afdd27e7