### PR TITLE
Remove unnecessary remembers in composables

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreFilterChips.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreFilterChips.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.design.system.chip.Chip
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
@@ -26,11 +25,10 @@ internal fun FilterChips(
     filters: Filters,
     onAction: (ExploreAction) -> Unit,
 ) {
-    val rememberedOnAction = rememberUpdatedState(onAction)
     Column(modifier = Modifier.padding(vertical = dimensions.padding.small)) {
-        PrimaryFilters(filters.primary, rememberedOnAction.value)
+        PrimaryFilters(filters.primary, onAction)
         Spacer(modifier = Modifier.size(dimensions.padding.small))
-        SecondaryFilters(filters.secondary, rememberedOnAction.value)
+        SecondaryFilters(filters.secondary, onAction)
     }
 }
 

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -54,10 +53,10 @@ internal fun RollerCoasterDetailsUi(
     onBackNavigation: () -> Unit,
     state: RollerCoasterDetailsState,
 ) {
-    val content = remember(state.content) { state.content }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val topBarState = remember(state.topBar) { state.topBar }
-    val onToggleFavourite = remember(onAction) { { onAction(ToggleFavourite) } }
+    val topBarState = state.topBar
+    val content = state.content
+    val onToggleFavourite = { onAction(ToggleFavourite) }
 
 
     Scaffold(

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiContent.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiContent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ListItem
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -38,21 +37,13 @@ internal fun SettingsContent(
     state: SettingsState,
     onAction: (SettingsAction) -> Unit,
 ) {
-    val onDynamicColorCheckedChange = remember(onAction) {
-        { checked: Boolean -> onAction(DynamicColorCheckedChange(checked)) }
+    val onDynamicColorCheckedChange: (Boolean) -> Unit = {
+        checked -> onAction(DynamicColorCheckedChange(checked))
     }
-    val launchThemePicker = remember(onAction) {
-        { onAction(LaunchAppThemePicker) }
-    }
-    val launchColorContrastPicker = remember(onAction) {
-        { onAction(LaunchAppColorContrastPicker) }
-    }
-    val launchLanguagePicker = remember(onAction) {
-        { onAction(LaunchAppLanguagePicker) }
-    }
-    val launchMeasurementSystemPicker = remember(onAction) {
-        { onAction(LaunchAppMeasurementSystemPicker) }
-    }
+    val launchThemePicker: () -> Unit = { onAction(LaunchAppThemePicker) }
+    val launchColorContrastPicker: () -> Unit = { onAction(LaunchAppColorContrastPicker) }
+    val launchLanguagePicker: () -> Unit = { onAction(LaunchAppLanguagePicker) }
+    val launchMeasurementSystemPicker: () -> Unit = { onAction(LaunchAppMeasurementSystemPicker) }
     LazyColumn(
         modifier = Modifier
             .padding(paddingValues)

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
@@ -4,8 +4,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.icon.Icon
 import com.sottti.roller.coasters.presentation.design.system.text.Text
 import com.sottti.roller.coasters.presentation.settings.model.SettingsTopBarState
@@ -29,9 +27,8 @@ private fun NavigationIcon(
     state: SettingsTopBarState,
     onBackNavigation: () -> Unit,
 ) {
-    val currentOnBack by rememberUpdatedState(onBackNavigation)
     Icon(
         iconState = state.icon,
-        onClick = { currentOnBack() },
+        onClick = onBackNavigation,
     )
 }

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/dialogs/SettingsUiAppColorContrastNotAvailableDialog.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/dialogs/SettingsUiAppColorContrastNotAvailableDialog.kt
@@ -1,7 +1,6 @@
 package com.sottti.roller.coasters.presentation.settings.ui.dialogs
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import com.sottti.roller.coasters.presentation.design.system.dialogs.informative.DialogInformative
 import com.sottti.roller.coasters.presentation.settings.model.AppColorContrastNotAvailableMessageState
 import com.sottti.roller.coasters.presentation.settings.model.SettingsAction
@@ -12,13 +11,10 @@ internal fun AppColorContrastNotAvailableDialog(
     state: AppColorContrastNotAvailableMessageState,
     onAction: (SettingsAction) -> Unit,
 ) {
-    val onDismiss = remember(onAction) {
-        { onAction(DismissAppColorContrastNotAvailableMessage) }
-    }
     DialogInformative(
         title = state.title,
         text = state.text,
         dismiss = state.dismiss,
-        onDismiss = onDismiss,
+        onDismiss = { onAction(DismissAppColorContrastNotAvailableMessage) },
     )
 }


### PR DESCRIPTION
## Summary
- drop rememberUpdatedState from settings top bar navigation icon
- simplify filter chip callbacks
- inline dismiss callback for color contrast error dialog
- inline callbacks inside SettingsContent
- simplify RollerCoasterDetailsUi state and callbacks

## Testing
- `./gradlew --version`

------
https://chatgpt.com/codex/tasks/task_e_68846c4443ec832e938d11992df407b0