### PR TITLE
Add spacer helper

### DIFF
--- a/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiContent.kt
+++ b/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiContent.kt
@@ -6,7 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import com.sottti.roller.coasters.presentation.utils.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -68,11 +68,11 @@ internal fun AboutMeUiContent(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             item { ProfileImage(state.profileImage) }
-            item { Spacer(modifier = Modifier.size(dimensions.padding.smallMedium)) }
+            item { Spacer(dimensions.padding.smallMedium) }
             item { Name(state.name) }
-            item { Spacer(modifier = Modifier.size(dimensions.padding.large)) }
+            item { Spacer(dimensions.padding.large) }
             item { SocialProfiles(onAction = onAction, state = state.socialProfiles) }
-            item { Spacer(modifier = Modifier.size(dimensions.padding.large)) }
+            item { Spacer(dimensions.padding.large) }
             item {
                 GetToKnowMe(
                     onAction = onAction,

--- a/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/pilledIcon/PilledIcon.kt
+++ b/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/pilledIcon/PilledIcon.kt
@@ -2,7 +2,7 @@ package com.sottti.roller.coasters.presentation.design.system.icons.ui.pilledIco
 
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
+import com.sottti.roller.coasters.presentation.utils.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Card
@@ -27,7 +27,7 @@ public fun PilledIcon(
 ) {
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Graphic(iconState = iconState, onClick = onClick)
-        Spacer(modifier = Modifier.size(dimensions.padding.smallMedium))
+        Spacer(dimensions.padding.smallMedium)
         Text(text)
 
     }

--- a/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLarge.kt
+++ b/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLarge.kt
@@ -2,7 +2,7 @@ package com.sottti.roller.coasters.presentation.design.system.roller.coaster.car
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import com.sottti.roller.coasters.presentation.utils.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -88,7 +88,7 @@ private fun Footer(
                 textColor = colors.onSurfaceVariant,
             )
         }
-        Spacer(modifier = Modifier.size(dimensions.padding.smallMedium))
+        Spacer(dimensions.padding.smallMedium)
         stat?.let {
             Column(horizontalAlignment = Alignment.End) {
                 Text.Label.Small(

--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreFilterChips.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreFilterChips.kt
@@ -4,7 +4,7 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Spacer
+import com.sottti.roller.coasters.presentation.utils.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -29,7 +29,7 @@ internal fun FilterChips(
     val rememberedOnAction = rememberUpdatedState(onAction)
     Column(modifier = Modifier.padding(vertical = dimensions.padding.small)) {
         PrimaryFilters(filters.primary, rememberedOnAction.value)
-        Spacer(modifier = Modifier.size(dimensions.padding.small))
+        Spacer(dimensions.padding.small)
         SecondaryFilters(filters.secondary, rememberedOnAction.value)
     }
 }

--- a/presentation/utils/src/main/kotlin/com/sottti/roller/coasters/presentation/utils/spacer.kt
+++ b/presentation/utils/src/main/kotlin/com/sottti/roller/coasters/presentation/utils/spacer.kt
@@ -1,0 +1,12 @@
+package com.sottti.roller.coasters.presentation.utils
+
+import androidx.compose.foundation.layout.Spacer as ComposeSpacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+
+@Composable
+public fun Spacer(size: Dp) {
+    ComposeSpacer(modifier = Modifier.size(size))
+}


### PR DESCRIPTION
## Summary
- add new `Spacer` overload that accepts `Dp`
- use new helper in icons, card and explore modules
- update AboutMe screen to use new helper

## Testing
- `./gradlew :presentation:utils:assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688476b863a0832e96f18addc7637c28