### PR TITLE
Add stable keys to compose lists

### DIFF
--- a/presentation/design-system/playground/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/playground/RainbowLazyColumn.kt
+++ b/presentation/design-system/playground/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/playground/RainbowLazyColumn.kt
@@ -22,7 +22,10 @@ public fun RainbowLazyColumn(
         modifier = Modifier
             .fillMaxSize()
     ) {
-        items(rainbowColors(seedColor)) { color: Color ->
+        items(
+            rainbowColors(seedColor),
+            key = { color: Color -> color.hashCode() }
+        ) { color: Color ->
             Box(
                 modifier = Modifier
                     .fillMaxWidth()

--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreContent.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreContent.kt
@@ -70,7 +70,10 @@ private fun RollerCoasters(
             item { FillMaxWidthProgressIndicator() }
         }
 
-        items(rollerCoasters.itemCount) { index ->
+        items(
+            rollerCoasters.itemCount,
+            key = { index -> rollerCoasters[index]?.id ?: index }
+        ) { index ->
             rollerCoasters[index]?.let { rollerCoaster ->
                 RollerCoaster(
                     onAction = onAction,

--- a/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiContent.kt
+++ b/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiContent.kt
@@ -71,7 +71,10 @@ private fun RollerCoasters(
             item { FillMaxWidthProgressIndicator() }
         }
 
-        items(rollerCoasters.itemCount) { index ->
+        items(
+            rollerCoasters.itemCount,
+            key = { index -> rollerCoasters[index]?.id ?: index }
+        ) { index ->
             rollerCoasters[index]?.let { rollerCoaster ->
                 RollerCoaster(
                     onNavigateToRollerCoaster = onNavigateToRollerCoaster,

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiContent.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiContent.kt
@@ -105,7 +105,10 @@ private fun SearchResults(
                     .nestedScroll(connection = scrollBehavior.nestedScrollConnection)
 
             ) {
-                items(items = state) { result ->
+                items(
+                    items = state,
+                    key = { result -> result.id }
+                ) { result ->
                     RollerCoasterCard.Small(
                         imageUrl = result.imageUrl,
                         parkName = result.parkName,


### PR DESCRIPTION
## Summary
- provide keys for search results
- provide keys for explore screen items
- provide keys for favourites list
- provide keys for color list in playground

## Testing
- `./gradlew test --no-daemon` *(fails: No valid plugin descriptors and build not finished)*

------
https://chatgpt.com/codex/tasks/task_e_68846d6b3f94832eb5001f34089e22c2