### PR TITLE
Reduce Paparazzi test boilerplate

### DIFF
--- a/presentation/about-me/src/test/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiBottomSheetContentSnapshotTest.kt
+++ b/presentation/about-me/src/test/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiBottomSheetContentSnapshotTest.kt
@@ -1,48 +1,28 @@
 package com.sottti.roller.coasters.presentation.about.me.ui
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.about.me.model.AboutMeBottomSheetPreviewState
 import com.sottti.roller.coasters.presentation.about.me.ui.bottomsheets.AboutMeUiBottomSheetContentPreview
 import com.sottti.roller.coasters.presentation.about.me.ui.bottomsheets.AboutMeUiBottomSheetContentStateProvider
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class AboutMeUiBottomSheetContentSnapshotTest(
     nightMode: NightMode,
-    private val state: AboutMeBottomSheetPreviewState,
-) {
+    state: AboutMeBottomSheetPreviewState,
+) : BasePaparazziSnapshotTest<AboutMeBottomSheetPreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            AboutMeUiBottomSheetContentPreview(state)
-        }
+    override fun snapshotContent(state: AboutMeBottomSheetPreviewState) {
+        AboutMeUiBottomSheetContentPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            AboutMeUiBottomSheetContentStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            AboutMeUiBottomSheetContentStateProvider().paparazziParameters()
     }
 }

--- a/presentation/about-me/src/test/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiSnapshotTest.kt
+++ b/presentation/about-me/src/test/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiSnapshotTest.kt
@@ -1,46 +1,27 @@
 package com.sottti.roller.coasters.presentation.about.me.ui
 
 import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_6_PRO
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.about.me.model.AboutMePreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class AboutMeUiSnapshotTest(
     nightMode: NightMode,
-    private val state: AboutMePreviewState,
-) {
+    state: AboutMePreviewState,
+) : BasePaparazziSnapshotTest<AboutMePreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            AboutMeUiPreview(state)
-        }
+    override fun snapshotContent(state: AboutMePreviewState) {
+        AboutMeUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            AboutMeUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            AboutMeUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/card-grid/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/card/grid/CardGridSnapshotTest.kt
+++ b/presentation/design-system/card-grid/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/card/grid/CardGridSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.card.grid
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class CardGridSnapshotTest(
     nightMode: NightMode,
-    private val state: QuadCardGridState,
+    state: QuadCardGridState,
+) : BasePaparazziSnapshotTest<QuadCardGridState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            QuadCardGridPreview(state)
-        }
+    override fun snapshotContent(state: QuadCardGridState) {
+        QuadCardGridPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            QuadCardGridStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            QuadCardGridStateProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/card-grid/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/card/grid/MonoGridSnapshotTest.kt
+++ b/presentation/design-system/card-grid/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/card/grid/MonoGridSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.card.grid
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class MonoGridSnapshotTest(
     nightMode: NightMode,
-    private val state: MonoCardGridState,
+    state: MonoCardGridState,
+) : BasePaparazziSnapshotTest<MonoCardGridState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            MonoCardGridPreview(state)
-        }
+    override fun snapshotContent(state: MonoCardGridState) {
+        MonoCardGridPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            MonoCardGridStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            MonoCardGridStateProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/chip/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/chip/ChipSnapshotTest.kt
+++ b/presentation/design-system/chip/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/chip/ChipSnapshotTest.kt
@@ -1,47 +1,31 @@
 package com.sottti.roller.coasters.presentation.design.system.chip
 
 import app.cash.paparazzi.DeviceConfig.Companion.PIXEL_6_PRO
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ChipSnapshotTest(
     nightMode: NightMode,
-    private val state: ChipState,
+    state: ChipState,
+) : BasePaparazziSnapshotTest<ChipState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            ChipPreview(state)
-        }
+    override fun snapshotContent(state: ChipState) {
+        ChipPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            ChipPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            ChipPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/dialogs/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/informative/DialogInformativeSnapshotTest.kt
+++ b/presentation/design-system/dialogs/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/informative/DialogInformativeSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.dialogs.informative
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class DialogInformativeSnapshotTest(
     nightMode: NightMode,
-    private val state: DialogInformativeState,
+    state: DialogInformativeState,
+) : BasePaparazziSnapshotTest<DialogInformativeState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            DialogInformativePreview(state)
-        }
+    override fun snapshotContent(state: DialogInformativeState) {
+        DialogInformativePreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            DialogInformativePreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            DialogInformativePreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/dialogs/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/radioButtons/DialogWithRadioButtonsSnapshotTest.kt
+++ b/presentation/design-system/dialogs/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/radioButtons/DialogWithRadioButtonsSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.dialogs.radioButtons
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class DialogWithRadioButtonsSnapshotTest(
     nightMode: NightMode,
-    private val state: DialogWithRadioButtonsState,
+    state: DialogWithRadioButtonsState,
+) : BasePaparazziSnapshotTest<DialogWithRadioButtonsState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            DialogWithRadioButtonsPreview(state)
-        }
+    override fun snapshotContent(state: DialogWithRadioButtonsState) {
+        DialogWithRadioButtonsPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            DialogWithRadioButtonsPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            DialogWithRadioButtonsPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/hero-image/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/progress/indicators/ProfilePictureSnapshotTest.kt
+++ b/presentation/design-system/hero-image/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/progress/indicators/ProfilePictureSnapshotTest.kt
@@ -1,50 +1,33 @@
 package com.sottti.roller.coasters.presentation.design.system.progress.indicators
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.design.system.hero.image.HeroImagePreview
 import com.sottti.roller.coasters.presentation.design.system.hero.image.HeroImageState
 import com.sottti.roller.coasters.presentation.design.system.hero.image.ProfilePicturePreviewProvider
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ProfilePictureSnapshotTest(
     nightMode: NightMode,
-    private val state: HeroImageState,
+    state: HeroImageState,
+) : BasePaparazziSnapshotTest<HeroImageState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            HeroImagePreview(state)
-        }
+    override fun snapshotContent(state: HeroImageState) {
+        HeroImagePreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            ProfilePicturePreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            ProfilePicturePreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/circledIcon/CircledIconSnapshotTest.kt
+++ b/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/circledIcon/CircledIconSnapshotTest.kt
@@ -1,28 +1,21 @@
 package com.sottti.roller.coasters.presentation.design.system.icons.circledIcon
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.circledIcon.CircledIconOnBackgroundPreview
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.circledIcon.CircledIconOnSurfacePreview
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class CircledIconSnapshotTest(
     nightMode: NightMode,
+) : BasePaparazziSnapshotTest<Unit>(
+    nightMode,
+    Unit,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
-
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
 
     @Test
     fun snapshotOnBackgroundTest() {

--- a/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/icon/IconSnapshotTest.kt
+++ b/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/icon/IconSnapshotTest.kt
@@ -1,50 +1,33 @@
 package com.sottti.roller.coasters.presentation.design.system.icons.icon
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.icon.IconPreview
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.icon.IconPreviewProvider
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.icon.IconPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class IconSnapshotTest(
     nightMode: NightMode,
-    private val state: IconPreviewState,
+    state: IconPreviewState,
+) : BasePaparazziSnapshotTest<IconPreviewState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            IconPreview(state)
-        }
+    override fun snapshotContent(state: IconPreviewState) {
+        IconPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            IconPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            IconPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/pilledIcon/PilledIconSnapshotTest.kt
+++ b/presentation/design-system/icons/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/pilledIcon/PilledIconSnapshotTest.kt
@@ -1,50 +1,33 @@
 package com.sottti.roller.coasters.presentation.design.system.icons.pilledIcon
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.pilledIcon.PilledIconPreview
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.pilledIcon.PilledIconPreviewProvider
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.pilledIcon.PilledIconPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class PilledIconSnapshotTest(
     nightMode: NightMode,
-    private val state: PilledIconPreviewState,
+    state: PilledIconPreviewState,
+) : BasePaparazziSnapshotTest<PilledIconPreviewState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            PilledIconPreview(state)
-        }
+    override fun snapshotContent(state: PilledIconPreviewState) {
+        PilledIconPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            PilledIconPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            PilledIconPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/progress-indicators/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/progress/indicators/ProgressIndicatorSnapshotTest.kt
+++ b/presentation/design-system/progress-indicators/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/progress/indicators/ProgressIndicatorSnapshotTest.kt
@@ -1,48 +1,31 @@
 package com.sottti.roller.coasters.presentation.design.system.progress.indicators
 
 import androidx.compose.ui.Modifier
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ProgressIndicatorSnapshotTest(
     nightMode: NightMode,
-    private val modifier: Modifier,
+    modifier: Modifier,
+) : BasePaparazziSnapshotTest<Modifier>(
+    nightMode,
+    modifier,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            ProgressIndicatorPreview(modifier)
-        }
+    override fun snapshotContent(state: Modifier) {
+        ProgressIndicatorPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            ProgressIndicatorPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            ProgressIndicatorPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/roller-coaster-card/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLargeSnapshotTest.kt
+++ b/presentation/design-system/roller-coaster-card/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLargeSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.roller.coaster.card.large
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class RollerCoasterCardLargeSnapshotTest(
     nightMode: NightMode,
-    private val state: RollerCoasterCardLargeState,
+    state: RollerCoasterCardLargeState,
+) : BasePaparazziSnapshotTest<RollerCoasterCardLargeState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            RollerCoasterCardLargePreview(state)
-        }
+    override fun snapshotContent(state: RollerCoasterCardLargeState) {
+        RollerCoasterCardLargePreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            RollerCoasterCardLargePreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state as Any),
-                        arrayOf(NightMode.NIGHT, state as Any),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            RollerCoasterCardLargePreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/roller-coaster-card/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/small/RollerCoasterCardSmallSnapshotTest.kt
+++ b/presentation/design-system/roller-coaster-card/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/small/RollerCoasterCardSmallSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.roller.coaster.card.small
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class RollerCoasterCardSmallSnapshotTest(
     nightMode: NightMode,
-    private val state: RollerCoasterCardSmallState,
+    state: RollerCoasterCardSmallState,
+) : BasePaparazziSnapshotTest<RollerCoasterCardSmallState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            RollerCoasterCardSmallPreview(state)
-        }
+    override fun snapshotContent(state: RollerCoasterCardSmallState) {
+        RollerCoasterCardSmallPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            RollerCoasterCardSmallPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state as Any),
-                        arrayOf(NightMode.NIGHT, state as Any),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            RollerCoasterCardSmallPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/search-box/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/search/box/SearchBoxSnapshotTest.kt
+++ b/presentation/design-system/search-box/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/search/box/SearchBoxSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.search.box
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class SearchBoxSnapshotTest(
     nightMode: NightMode,
-    private val state: SearchBoxViewState,
+    state: SearchBoxViewState,
+) : BasePaparazziSnapshotTest<SearchBoxViewState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            SearchBoxPreview(state)
-        }
+    override fun snapshotContent(state: SearchBoxViewState) {
+        SearchBoxPreview(state)
     }
 
     companion object Companion {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            SearchBoxViewStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            SearchBoxViewStateProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/switch/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/switchh/SwitchSnapshotTest.kt
+++ b/presentation/design-system/switch/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/switchh/SwitchSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.design.system.switchh
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class SwitchSnapshotTest(
     nightMode: NightMode,
-    private val state: SwitchState,
+    state: SwitchState,
+) : BasePaparazziSnapshotTest<SwitchState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            SwitchPreview(state)
-        }
+    override fun snapshotContent(state: SwitchState) {
+        SwitchPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            SwitchPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            SwitchPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/design-system/text/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/text/TextSnapshotTest.kt
+++ b/presentation/design-system/text/src/test/kotlin/com/sottti/roller/coasters/presentation/design/system/text/TextSnapshotTest.kt
@@ -1,32 +1,22 @@
 package com.sottti.roller.coasters.presentation.design.system.text
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class TextSnapshotTest(
     nightMode: NightMode,
+) : BasePaparazziSnapshotTest<Unit>(
+    nightMode,
+    Unit,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            TextPreview()
-        }
+    override fun snapshotContent(state: Unit) {
+        TextPreview()
     }
 
     companion object {

--- a/presentation/empty/src/test/kotlin/com/sottti/roller/coasters/presentation/empty/EmptySnapshotTest.kt
+++ b/presentation/empty/src/test/kotlin/com/sottti/roller/coasters/presentation/empty/EmptySnapshotTest.kt
@@ -1,45 +1,25 @@
 package com.sottti.roller.coasters.presentation.empty
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class EmptySnapshotTest(
     nightMode: NightMode,
-    private val state: EmptyState?,
-) {
+    state: EmptyState?,
+) : BasePaparazziSnapshotTest<EmptyState?>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            EmptyUiPreview(state)
-        }
+    override fun snapshotContent(state: EmptyState?) {
+        EmptyUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
         fun data(): Collection<Array<Any?>> =
-            EmptyUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+            EmptyUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/error/src/test/kotlin/com/sottti/roller/coasters/presentation/error/ErrorSnapshotTest.kt
+++ b/presentation/error/src/test/kotlin/com/sottti/roller/coasters/presentation/error/ErrorSnapshotTest.kt
@@ -1,45 +1,25 @@
 package com.sottti.roller.coasters.presentation.error
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ErrorSnapshotTest(
     nightMode: NightMode,
-    private val state: ErrorState?,
-) {
+    state: ErrorState?,
+) : BasePaparazziSnapshotTest<ErrorState?>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            ErrorUiPreview(state)
-        }
+    override fun snapshotContent(state: ErrorState?) {
+        ErrorUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
         fun data(): Collection<Array<Any?>> =
-            ErrorUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+            ErrorUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/explore/src/test/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreSnapshotTest.kt
+++ b/presentation/explore/src/test/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreSnapshotTest.kt
@@ -1,46 +1,26 @@
 package com.sottti.roller.coasters.presentation.explore.ui
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.explore.model.ExplorePreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ExploreSnapshotTest(
     nightMode: NightMode,
-    private val state: ExplorePreviewState,
-) {
+    state: ExplorePreviewState,
+) : BasePaparazziSnapshotTest<ExplorePreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            ExploreUiPreview(state)
-        }
+    override fun snapshotContent(state: ExplorePreviewState) {
+        ExploreUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            ExploreUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            ExploreUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/favourites/src/test/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiSnapshotTest.kt
+++ b/presentation/favourites/src/test/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiSnapshotTest.kt
@@ -1,46 +1,26 @@
 package com.sottti.roller.coasters.presentation.favourites.ui
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.favourites.model.FavouritesPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class FavouritesUiSnapshotTest(
     nightMode: NightMode,
-    private val state: FavouritesPreviewState,
-) {
+    state: FavouritesPreviewState,
+) : BasePaparazziSnapshotTest<FavouritesPreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            FavouritesUiPreview(state)
-        }
+    override fun snapshotContent(state: FavouritesPreviewState) {
+        FavouritesUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            FavouritesUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            FavouritesUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/image-loading/src/test/kotlin/com/sottti/roller/coasters/presentation/image/loading/ImageSnapshotTest.kt
+++ b/presentation/image-loading/src/test/kotlin/com/sottti/roller/coasters/presentation/image/loading/ImageSnapshotTest.kt
@@ -1,47 +1,30 @@
 package com.sottti.roller.coasters.presentation.image.loading
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.ide.common.rendering.api.SessionParams
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class ImageSnapshotTest(
     nightMode: NightMode,
-    private val state: ImageState,
+    state: ImageState,
+) : BasePaparazziSnapshotTest<ImageState>(
+    nightMode,
+    state,
+    renderingMode = SessionParams.RenderingMode.SHRINK,
 ) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        renderingMode = SessionParams.RenderingMode.SHRINK,
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            ImagePreview(state)
-        }
+    override fun snapshotContent(state: ImageState) {
+        ImagePreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            ImageStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            ImageStateProvider().paparazziParameters()
     }
 }

--- a/presentation/informative/src/test/kotlin/com/sottti/roller/coasters/presentation/informative/InformativeSnapshotTest.kt
+++ b/presentation/informative/src/test/kotlin/com/sottti/roller/coasters/presentation/informative/InformativeSnapshotTest.kt
@@ -1,45 +1,25 @@
 package com.sottti.roller.coasters.presentation.informative
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class InformativeSnapshotTest(
     nightMode: NightMode,
-    private val state: InformativeState,
-) {
+    state: InformativeState,
+) : BasePaparazziSnapshotTest<InformativeState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            InformativeUiPreview(state)
-        }
+    override fun snapshotContent(state: InformativeState) {
+        InformativeUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            InformativeUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            InformativeUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/roller-coaster-details/src/test/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsSnapshotTest.kt
+++ b/presentation/roller-coaster-details/src/test/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsSnapshotTest.kt
@@ -2,49 +2,29 @@ package com.sottti.roller.coasters.presentation.roller.coaster.details.ui
 
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.platform.LocalInspectionMode
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.roller.coaster.details.model.RollerCoasterDetailsPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class RollerCoasterDetailsSnapshotTest(
     nightMode: NightMode,
-    private val state: RollerCoasterDetailsPreviewState,
-) {
+    state: RollerCoasterDetailsPreviewState,
+) : BasePaparazziSnapshotTest<RollerCoasterDetailsPreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            CompositionLocalProvider(LocalInspectionMode provides true) {
-                RollerCoasterDetailsUiPreview(state)
-            }
+    override fun snapshotContent(state: RollerCoasterDetailsPreviewState) {
+        CompositionLocalProvider(LocalInspectionMode provides true) {
+            RollerCoasterDetailsUiPreview(state)
         }
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            RollerCoasterDetailsUiPreviewProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            RollerCoasterDetailsUiPreviewProvider().paparazziParameters()
     }
 }

--- a/presentation/search/src/test/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiSnapshotTest.kt
+++ b/presentation/search/src/test/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiSnapshotTest.kt
@@ -1,46 +1,26 @@
 package com.sottti.roller.coasters.presentation.search.ui
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.search.model.SearchPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class SearchUiSnapshotTest(
     nightMode: NightMode,
-    private val state: SearchPreviewState,
-) {
+    state: SearchPreviewState,
+) : BasePaparazziSnapshotTest<SearchPreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            SearchUiPreview(state)
-        }
+    override fun snapshotContent(state: SearchPreviewState) {
+        SearchUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            SearchUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            SearchUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/settings/src/test/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiSnapshotTest.kt
+++ b/presentation/settings/src/test/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiSnapshotTest.kt
@@ -1,46 +1,26 @@
 package com.sottti.roller.coasters.presentation.settings.ui
 
-import app.cash.paparazzi.DeviceConfig
-import app.cash.paparazzi.Paparazzi
+import com.sottti.roller.coasters.presentation.utils.BasePaparazziSnapshotTest
+import com.sottti.roller.coasters.presentation.utils.paparazziParameters
 import com.android.resources.NightMode
 import com.sottti.roller.coasters.presentation.settings.model.SettingsPreviewState
-import org.junit.Rule
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 
 @RunWith(Parameterized::class)
 internal class SettingsUiSnapshotTest(
     nightMode: NightMode,
-    private val state: SettingsPreviewState,
-) {
+    state: SettingsPreviewState,
+) : BasePaparazziSnapshotTest<SettingsPreviewState>(nightMode, state) {
 
-    @get:Rule
-    val paparazzi = Paparazzi(
-        deviceConfig = DeviceConfig.Companion.PIXEL_6_PRO.copy(nightMode = nightMode),
-        showSystemUi = false,
-        theme = "Theme.RollerCoasters",
-    )
-
-    @Test
-    fun snapshotTest() {
-        paparazzi.snapshot {
-            SettingsUiPreview(state)
-        }
+    override fun snapshotContent(state: SettingsPreviewState) {
+        SettingsUiPreview(state)
     }
 
     companion object {
         @JvmStatic
         @Parameterized.Parameters
-        fun data(): Collection<Array<Any>> =
-            SettingsUiStateProvider()
-                .values
-                .flatMap { state ->
-                    listOf(
-                        arrayOf(NightMode.NOTNIGHT, state),
-                        arrayOf(NightMode.NIGHT, state),
-                    )
-                }
-                .toList()
+        fun data(): Collection<Array<Any?>> =
+            SettingsUiStateProvider().paparazziParameters()
     }
 }

--- a/presentation/utils/src/main/kotlin/com/sottti/roller/coasters/presentation/utils/PaparazziExtensions.kt
+++ b/presentation/utils/src/main/kotlin/com/sottti/roller/coasters/presentation/utils/PaparazziExtensions.kt
@@ -1,0 +1,52 @@
+package com.sottti.roller.coasters.presentation.utils
+
+import app.cash.paparazzi.DeviceConfig
+import app.cash.paparazzi.Paparazzi
+import com.android.ide.common.rendering.api.SessionParams
+import com.android.resources.NightMode
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Base class for Paparazzi snapshot tests to reduce boilerplate.
+ */
+abstract class BasePaparazziSnapshotTest<T>(
+    nightMode: NightMode,
+    private val state: T,
+    renderingMode: SessionParams.RenderingMode = SessionParams.RenderingMode.NORMAL
+) {
+
+    @get:Rule
+    val paparazzi = Paparazzi(
+        deviceConfig = DeviceConfig.PIXEL_6_PRO.copy(nightMode = nightMode),
+        renderingMode = renderingMode,
+        showSystemUi = false,
+        theme = "Theme.RollerCoasters",
+    )
+
+    /**
+     * Implement this method with the composable that should be snapshotted.
+     */
+    protected abstract fun snapshotContent(state: T)
+
+    @Test
+    fun snapshotTest() {
+        paparazzi.snapshot {
+            snapshotContent(state)
+        }
+    }
+}
+
+/**
+ * Helper to convert a [PreviewParameterProvider] into JUnit parameters including
+ * light and dark [NightMode] variants.
+ */
+fun <T> PreviewParameterProvider<T>.paparazziParameters(): Collection<Array<Any?>> =
+    values.flatMap { state ->
+        listOf(
+            arrayOf(NightMode.NOTNIGHT, state),
+            arrayOf(NightMode.NIGHT, state)
+        )
+    }.toList()
+


### PR DESCRIPTION
## Summary
- add `BasePaparazziSnapshotTest` and helper extension
- use the base class in snapshot tests to remove repeated setup

## Testing
- `./gradlew test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688645e008b4832e86055229e1d86f17