### PR TITLE
Use sequence builder in preview providers

### DIFF
--- a/presentation/design-system/chip/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/chip/ChipPreviewProvider.kt
+++ b/presentation/design-system/chip/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/chip/ChipPreviewProvider.kt
@@ -4,12 +4,12 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.design.system.icons.data.Icons
 
 internal class ChipPreviewProvider : PreviewParameterProvider<ChipState> {
-    override val values = buildList {
+    override val values: Sequence<ChipState> = sequence {
         leadingIconValues().forEach { leadingIcon ->
             selectedValues().forEach { enabled ->
                 expandedValues().forEach { expanded ->
                     labelResIdValues().forEach { checked ->
-                        add(
+                        yield(
                             ChipState(
                                 expanded = expanded,
                                 labelResId = checked,
@@ -21,7 +21,7 @@ internal class ChipPreviewProvider : PreviewParameterProvider<ChipState> {
                 }
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun expandedValues() = sequenceOf(false, true, null)

--- a/presentation/design-system/dialogs/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/informative/DialogInformativePreviewProvider.kt
+++ b/presentation/design-system/dialogs/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/informative/DialogInformativePreviewProvider.kt
@@ -4,11 +4,11 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.fixtures.FixturesR
 
 internal class DialogInformativePreviewProvider : PreviewParameterProvider<DialogInformativeState> {
-    override val values = buildList {
+    override val values: Sequence<DialogInformativeState> = sequence {
         titleValues().forEach { title ->
             textValues().forEach { text ->
                 dismissValues().forEach { dismiss ->
-                    add(
+                    yield(
                         DialogInformativeState(
                             dismiss = dismiss,
                             text = text,
@@ -18,7 +18,7 @@ internal class DialogInformativePreviewProvider : PreviewParameterProvider<Dialo
                 }
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun dismissValues() = listOf(

--- a/presentation/design-system/dialogs/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/radioButtons/DialogWithRadioButtonsPreviewProvider.kt
+++ b/presentation/design-system/dialogs/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dialogs/radioButtons/DialogWithRadioButtonsPreviewProvider.kt
@@ -6,11 +6,11 @@ import com.sottti.roller.coasters.presentation.fixtures.FixturesR
 
 internal class DialogWithRadioButtonsPreviewProvider :
     PreviewParameterProvider<DialogWithRadioButtonsState> {
-    override val values = buildList {
+    override val values: Sequence<DialogWithRadioButtonsState> = sequence {
         titleValues().forEach { title ->
             confirmValues().forEach { confirm ->
                 dismissValues().forEach { dismiss ->
-                    add(
+                    yield(
                         DialogWithRadioButtonsState(
                             confirm = confirm,
                             dismiss = dismiss,
@@ -21,7 +21,7 @@ internal class DialogWithRadioButtonsPreviewProvider :
                 }
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun confirmValues() = listOf(

--- a/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/icon/IconPreviewProvider.kt
+++ b/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/icon/IconPreviewProvider.kt
@@ -4,11 +4,11 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.design.system.icons.data.Icons
 
 internal class IconPreviewProvider : PreviewParameterProvider<IconPreviewState> {
-    override val values = buildList {
+    override val values: Sequence<IconPreviewState> = sequence {
         stateValues().forEach { state ->
             crossfadeValues().forEach { crossfade ->
                 onClickValues().forEach { onClick ->
-                    add(
+                    yield(
                         IconPreviewState(
                             crossfade = crossfade,
                             onClick = onClick,
@@ -18,7 +18,7 @@ internal class IconPreviewProvider : PreviewParameterProvider<IconPreviewState> 
                 }
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun crossfadeValues() = sequenceOf(false, true)

--- a/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLargePreviewProvider.kt
+++ b/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/large/RollerCoasterCardLargePreviewProvider.kt
@@ -10,9 +10,9 @@ import com.sottti.roller.coasters.presentation.fixtures.fixtureState
 internal class RollerCoasterCardLargePreviewProvider :
     PreviewParameterProvider<RollerCoasterCardLargeState> {
     override val values: Sequence<RollerCoasterCardLargeState> =
-        buildList {
+        sequence {
             foreverLoadingValues.forEach { foreverLoading ->
-                add(
+                yield(
                     RollerCoasterCardLargeState(
                         foreverLoading = foreverLoading,
                         imageUrl = fixtureImageUrl,
@@ -25,7 +25,7 @@ internal class RollerCoasterCardLargePreviewProvider :
                 )
             }
 
-        }.asSequence()
+        }
 }
 
 private val foreverLoadingValues = listOf(true, false)

--- a/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/small/RollerCoasterCardSmallPreviewProvider.kt
+++ b/presentation/design-system/roller-coaster-card/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/roller/coaster/card/small/RollerCoasterCardSmallPreviewProvider.kt
@@ -8,10 +8,10 @@ import com.sottti.roller.coasters.presentation.fixtures.fixtureRollerCoasterName
 internal class RollerCoasterCardSmallPreviewProvider :
     PreviewParameterProvider<RollerCoasterCardSmallState> {
     override val values: Sequence<RollerCoasterCardSmallState> =
-        buildList {
+        sequence {
             foreverLoadingValues.forEach { foreverLoading ->
                 imageUrlValues.forEach { imageUrl ->
-                    add(
+                    yield(
                         RollerCoasterCardSmallState(
                             foreverLoading = foreverLoading,
                             imageUrl = imageUrl,
@@ -22,7 +22,7 @@ internal class RollerCoasterCardSmallPreviewProvider :
                     )
                 }
             }
-        }.asSequence()
+        }
 }
 
 private val foreverLoadingValues = listOf(true, false)

--- a/presentation/design-system/search-box/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/search/box/SearchBoxViewStateProvider.kt
+++ b/presentation/design-system/search-box/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/search/box/SearchBoxViewStateProvider.kt
@@ -4,10 +4,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.domain.fixtures.COASTER_NAME
 
 internal class SearchBoxViewStateProvider : PreviewParameterProvider<SearchBoxViewState> {
-    override val values = buildList {
+    override val values: Sequence<SearchBoxViewState> = sequence {
         queryValues().forEach { query ->
             loadingValues().forEach { loading ->
-                add(
+                yield(
                     SearchBoxViewState(
                         hint = R.string.hint,
                         query = query,
@@ -17,7 +17,7 @@ internal class SearchBoxViewStateProvider : PreviewParameterProvider<SearchBoxVi
                 )
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun loadingValues() = listOf(false, true)

--- a/presentation/design-system/switch/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/switchh/SwitchPreviewProvider.kt
+++ b/presentation/design-system/switch/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/switchh/SwitchPreviewProvider.kt
@@ -3,10 +3,10 @@ package com.sottti.roller.coasters.presentation.design.system.switchh
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 
 internal class SwitchPreviewProvider : PreviewParameterProvider<SwitchState> {
-    override val values = buildList {
+    override val values: Sequence<SwitchState> = sequence {
         enabledValues().forEach { enabled ->
             checkedValues().forEach { checked ->
-                add(
+                yield(
                     SwitchState(
                         checked = checked,
                         enabled = enabled,
@@ -14,7 +14,7 @@ internal class SwitchPreviewProvider : PreviewParameterProvider<SwitchState> {
                 )
             }
         }
-    }.asSequence()
+    }
 }
 
 private fun checkedValues() = sequenceOf(true, false)

--- a/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/ImageViewStateProvider.kt
+++ b/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/ImageViewStateProvider.kt
@@ -7,8 +7,8 @@ import com.sottti.roller.coasters.presentation.fixtures.fixtureImageUrl
 internal class ImageStateProvider :
     PreviewParameterProvider<ImageState> {
     override val values: Sequence<ImageState> =
-        buildList {
-            add(
+        sequence {
+            yield(
                 ImageState(
                     contentDescription = fixtureContentDescription,
                     foreverLoading = true,
@@ -17,7 +17,7 @@ internal class ImageStateProvider :
                 ),
             )
             roundedCornersValues.forEach { roundedCorners ->
-                add(
+                yield(
                     ImageState(
                         contentDescription = fixtureContentDescription,
                         foreverLoading = false,
@@ -26,7 +26,7 @@ internal class ImageStateProvider :
                     )
                 )
             }
-        }.asSequence()
+        }
 }
 
 private val roundedCornersValues = listOf(false, true)


### PR DESCRIPTION
## Summary
- switch preview parameter providers to use `sequence { yield(...) }`
- replace old `buildList { ... }.asSequence()` pattern

## Testing
- `./gradlew test --no-daemon` *(fails: The file `/workspace/RollerCoasters/local.properties` could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_688644af67ac832ea17fc37b6350da45