### PR TITLE
chore: remove presentation tests dependency

### DIFF
--- a/presentation/about-me/build.gradle.kts
+++ b/presentation/about-me/build.gradle.kts
@@ -41,5 +41,4 @@ dependencies {
     testImplementation(libs.kotlin.coroutines.test)
     testImplementation(libs.mockk)
     testImplementation(libs.truth)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/card-grid/build.gradle.kts
+++ b/presentation/design-system/card-grid/build.gradle.kts
@@ -23,5 +23,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.text))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/chip/build.gradle.kts
+++ b/presentation/design-system/chip/build.gradle.kts
@@ -22,5 +22,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.text))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/dialogs/build.gradle.kts
+++ b/presentation/design-system/dialogs/build.gradle.kts
@@ -23,5 +23,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/hero-image/build.gradle.kts
+++ b/presentation/design-system/hero-image/build.gradle.kts
@@ -22,5 +22,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.dimensions))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/icons/build.gradle.kts
+++ b/presentation/design-system/icons/build.gradle.kts
@@ -24,5 +24,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
     implementation(project(module.presentation.utils))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/illustrations/build.gradle.kts
+++ b/presentation/design-system/illustrations/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.dimensions))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/images/build.gradle.kts
+++ b/presentation/design-system/images/build.gradle.kts
@@ -22,5 +22,4 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/map/build.gradle.kts
+++ b/presentation/design-system/map/build.gradle.kts
@@ -23,5 +23,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.images))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/progress-indicators/build.gradle.kts
+++ b/presentation/design-system/progress-indicators/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.dimensions))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/roller-coaster-card/build.gradle.kts
+++ b/presentation/design-system/roller-coaster-card/build.gradle.kts
@@ -26,5 +26,4 @@ dependencies {
     implementation(project(module.presentation.imageLoading))
     implementation(project(module.presentation.previews))
     implementation(project(module.presentation.utils))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/search-box/build.gradle.kts
+++ b/presentation/design-system/search-box/build.gradle.kts
@@ -25,5 +25,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.text))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/switch/build.gradle.kts
+++ b/presentation/design-system/switch/build.gradle.kts
@@ -20,5 +20,4 @@ dependencies {
     implementation(platform(libs.compose.bom))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/design-system/text/build.gradle.kts
+++ b/presentation/design-system/text/build.gradle.kts
@@ -21,5 +21,4 @@ dependencies {
     implementation(project(module.presentation.designSystem.dimensions))
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/empty/build.gradle.kts
+++ b/presentation/empty/build.gradle.kts
@@ -26,5 +26,4 @@ dependencies {
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.informative))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/error/build.gradle.kts
+++ b/presentation/error/build.gradle.kts
@@ -26,5 +26,4 @@ dependencies {
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.informative))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/explore/build.gradle.kts
+++ b/presentation/explore/build.gradle.kts
@@ -49,5 +49,4 @@ dependencies {
     testImplementation(libs.paging.testing)
     testImplementation(libs.truth)
     testImplementation(libs.turbine)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/favourites/build.gradle.kts
+++ b/presentation/favourites/build.gradle.kts
@@ -44,5 +44,4 @@ dependencies {
     testImplementation(libs.paging.testing)
     testImplementation(libs.truth)
     testImplementation(libs.turbine)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/home/build.gradle.kts
+++ b/presentation/home/build.gradle.kts
@@ -35,5 +35,4 @@ dependencies {
     implementation(project(module.presentation.search))
     implementation(project(module.presentation.settings))
     ksp(libs.hilt.compiler)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/image-loading/build.gradle.kts
+++ b/presentation/image-loading/build.gradle.kts
@@ -25,5 +25,4 @@ dependencies {
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.previews))
     runtimeOnly(libs.startup.runtime)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/informative/build.gradle.kts
+++ b/presentation/informative/build.gradle.kts
@@ -29,5 +29,4 @@ dependencies {
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.previews))
     implementation(project(module.presentation.utils))
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/roller-coaster-details/build.gradle.kts
+++ b/presentation/roller-coaster-details/build.gradle.kts
@@ -42,5 +42,4 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.truth)
     testImplementation(libs.turbine)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/search/build.gradle.kts
+++ b/presentation/search/build.gradle.kts
@@ -37,5 +37,4 @@ dependencies {
     implementation(project(module.presentation.topBars))
     implementation(project(module.presentation.utils))
     ksp(libs.hilt.compiler)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/settings/build.gradle.kts
+++ b/presentation/settings/build.gradle.kts
@@ -39,5 +39,4 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.truth)
     testImplementation(libs.turbine)
-    testImplementation(project(module.presentation.tests))
 }

--- a/presentation/top-bars/build.gradle.kts
+++ b/presentation/top-bars/build.gradle.kts
@@ -25,5 +25,4 @@ dependencies {
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.navigation))
     implementation(project(module.presentation.previews))
-    testImplementation(project(module.presentation.tests))
 }


### PR DESCRIPTION
## Summary
- remove presentation:tests dependency from presentation modules

## Testing
- `./gradlew test` *(fails: Could not create task ':app:testReleaseUnitTest'. Cannot find a Java installation matching {languageVersion=17})*

------
https://chatgpt.com/codex/tasks/task_e_68934baec17c832ea43833e8b207de29