### PR TITLE
Rename settings icon helper in MainTopBar

### DIFF
--- a/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUi.kt
+++ b/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUi.kt
@@ -34,7 +34,7 @@ public fun MainTopBar(
     }
 
     TopAppBar(
-        actions = { Icon(onNavigateToSettings) },
+        actions = { SettingsIcon(onNavigateToSettings) },
         colors = colors,
         scrollBehavior = scrollBehavior,
         title = { Title(titleResId, showTitle) },
@@ -58,7 +58,7 @@ private fun Title(
 }
 
 @Composable
-private fun Icon(onNavigateToSettings: () -> Unit) {
+private fun SettingsIcon(onNavigateToSettings: () -> Unit) {
     Icon(
         iconState = Icons.Settings.outlined,
         onClick = { onNavigateToSettings() },


### PR DESCRIPTION
## Summary
- rename local Icon helper to SettingsIcon to avoid name collision
- adjust MainTopBar actions to use new SettingsIcon helper

## Testing
- `./gradlew :presentation:top-bars:test` *(fails: Could not find Java installation matching languageVersion=17)*

------
https://chatgpt.com/codex/tasks/task_e_6899d83c39e8832e83bb3a46139dceca