### PR TITLE
Rename PilledIcon label helper for clarity

### DIFF
--- a/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/pilledIcon/PilledIcon.kt
+++ b/presentation/design-system/icons/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/icons/ui/pilledIcon/PilledIcon.kt
@@ -27,7 +27,7 @@ public fun PilledIcon(
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Graphic(iconState = iconState, onClick = onClick)
         Spacer(dimensions.padding.smallMedium)
-        Text(text)
+        PilledLabel(text)
 
     }
 }
@@ -53,7 +53,7 @@ private fun Graphic(
 }
 
 @Composable
-private fun Text(text: Int) {
+private fun PilledLabel(text: Int) {
     Text.Label.Medium(
         textResId = text,
         textColor = colors.onBackground,


### PR DESCRIPTION
## Summary
- rename `Text` helper to `PilledLabel`
- update `PilledIcon` to call `PilledLabel`

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching version 17)*

------
https://chatgpt.com/codex/tasks/task_e_6899d81de484832eb2d32913a20b5962