### PR TITLE
Fix NavHost recursion by renaming Home module host

### DIFF
--- a/presentation/home/src/main/kotlin/com/sottti/roller/coasters/presentation/home/ui/HomeUiNavigationBar.kt
+++ b/presentation/home/src/main/kotlin/com/sottti/roller/coasters/presentation/home/ui/HomeUiNavigationBar.kt
@@ -88,7 +88,7 @@ internal fun NavigationBar(
             )
         },
     ) { padding ->
-        NavHost(
+        HomeNavHost(
             navController = navController,
             onNavigateToRollerCoaster = onNavigateToRollerCoaster,
             onNavigateToSettings = onNavigateToSettings,
@@ -109,7 +109,7 @@ internal fun NavigationBar(
 }
 
 @Composable
-private fun NavHost(
+private fun HomeNavHost(
     navController: NavHostController,
     startDestination: Explore,
     padding: PaddingValues,


### PR DESCRIPTION
## Summary
- Rename private `NavHost` composable to `HomeNavHost`
- Update invocation to prevent accidental recursion with framework `NavHost`

## Testing
- `./gradlew :presentation:home:test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8376d94832e8cb5b33e5c7495a0