### PR TITLE
Handle Material3 experimental APIs internally

### DIFF
--- a/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiStateProvider.kt
+++ b/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/AboutMeUiStateProvider.kt
@@ -1,12 +1,10 @@
 package com.sottti.roller.coasters.presentation.about.me.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.about.me.data.initialState
 import com.sottti.roller.coasters.presentation.about.me.model.AboutMePreviewState
 
-@OptIn(ExperimentalMaterial3Api::class)
 internal class AboutMeUiStateProvider : PreviewParameterProvider<AboutMePreviewState> {
     override val values: Sequence<AboutMePreviewState> = sequenceOf(
         AboutMePreviewState(

--- a/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/bottomsheets/AboutMeUiBottomSheetContentStateProvider.kt
+++ b/presentation/about-me/src/main/kotlin/com/sottti/roller/coasters/presentation/about/me/ui/bottomsheets/AboutMeUiBottomSheetContentStateProvider.kt
@@ -1,12 +1,10 @@
 package com.sottti.roller.coasters.presentation.about.me.ui.bottomsheets
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.about.me.data.initialState
 import com.sottti.roller.coasters.presentation.about.me.model.AboutMeBottomSheetPreviewState
 import com.sottti.roller.coasters.presentation.about.me.model.TopicDescription
 
-@OptIn(ExperimentalMaterial3Api::class)
 internal class AboutMeUiBottomSheetContentStateProvider :
     PreviewParameterProvider<AboutMeBottomSheetPreviewState> {
     override val values: Sequence<AboutMeBottomSheetPreviewState> = sequenceOf(

--- a/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUi.kt
+++ b/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUi.kt
@@ -110,7 +110,6 @@ private fun FavouritesUiEffects(
 
 @Composable
 @RollerCoastersPreview
-@OptIn(ExperimentalMaterial3Api::class)
 internal fun FavouritesUiPreview(
     @PreviewParameter(FavouritesUiStateProvider::class)
     state: FavouritesPreviewState,

--- a/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiStateProvider.kt
+++ b/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiStateProvider.kt
@@ -1,7 +1,6 @@
 package com.sottti.roller.coasters.presentation.favourites.ui
 
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.paging.LoadState
 import androidx.paging.LoadState.Loading
@@ -64,7 +63,6 @@ private val errorState = favouritesPreviewState(
     data = emptyList(),
 )
 
-@OptIn(ExperimentalMaterial3Api::class)
 private fun favouritesPreviewState(
     refreshState: LoadState = NotLoading(endOfPaginationReached = false),
     appendState: LoadState = NotLoading(endOfPaginationReached = false),

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiTopBar.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiTopBar.kt
@@ -19,7 +19,7 @@ import com.sottti.roller.coasters.presentation.roller.coaster.details.model.Favo
 import com.sottti.roller.coasters.presentation.roller.coaster.details.model.TopBarState
 
 @Composable
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalMaterial3Api::class)
 internal fun TopBar(
     onBackNavigation: () -> Unit,
     onToggleFavourite: () -> Unit,

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiStateProvider.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiStateProvider.kt
@@ -1,6 +1,5 @@
 package com.sottti.roller.coasters.presentation.settings.ui
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.domain.settings.model.colorContrast.AppColorContrast
 import com.sottti.roller.coasters.domain.settings.model.dynamicColor.AppDynamicColor
@@ -21,7 +20,6 @@ import com.sottti.roller.coasters.presentation.settings.data.reducer.updateDynam
 import com.sottti.roller.coasters.presentation.settings.model.SettingsPreviewState
 import kotlin.math.min
 
-@OptIn(ExperimentalMaterial3Api::class)
 internal class SettingsUiStateProvider : PreviewParameterProvider<SettingsPreviewState> {
 
     override val values: Sequence<SettingsPreviewState> = sequence {

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
@@ -11,7 +11,7 @@ import com.sottti.roller.coasters.presentation.design.system.text.Text
 import com.sottti.roller.coasters.presentation.settings.model.SettingsTopBarState
 
 @Composable
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalMaterial3Api::class)
 internal fun TopBar(
     onBackNavigation: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior,

--- a/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUi.kt
+++ b/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUi.kt
@@ -21,7 +21,7 @@ import com.sottti.roller.coasters.presentation.design.system.themes.RollerCoaste
 import com.sottti.roller.coasters.presentation.previews.RollerCoastersPreview
 
 @Composable
-@ExperimentalMaterial3Api
+@OptIn(ExperimentalMaterial3Api::class)
 public fun MainTopBar(
     onNavigateToSettings: () -> Unit,
     scrollBehavior: TopAppBarScrollBehavior? = null,
@@ -67,7 +67,6 @@ private fun Icon(onNavigateToSettings: () -> Unit) {
 
 @Composable
 @RollerCoastersPreview
-@OptIn(ExperimentalMaterial3Api::class)
 internal fun MainTopBarPreview(
     @PreviewParameter(MainTopBarUiStateProvider::class)
     state: MainTopBarState,

--- a/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUiStateProvider.kt
+++ b/presentation/top-bars/src/main/kotlin/com/sottti/roller/coasters/presentation/top/bars/ui/MainTopBarUiStateProvider.kt
@@ -1,11 +1,9 @@
 package com.sottti.roller.coasters.presentation.top.bars.ui
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import com.sottti.roller.coasters.presentation.fixtures.R
 
 internal class MainTopBarUiStateProvider : PreviewParameterProvider<MainTopBarState> {
-    @OptIn(ExperimentalMaterial3Api::class)
     override val values: Sequence<MainTopBarState> = sequence {
         showTitleValues().forEach { showTitle ->
             titleResIdValues().forEach { titleResId ->


### PR DESCRIPTION
## Summary
- wrap experimental Material3 APIs with `@OptIn` in top bar composables
- drop unnecessary `@OptIn` annotations from previews and state providers

## Testing
- `./gradlew test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6899d8143030832e81e35b7910bcf385