### PR TITLE
Fix coroutine handling for scroll events

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUi.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUi.kt
@@ -111,7 +111,7 @@ private fun ExploreUiEffects(
     LaunchedEffect(events) {
         events.collect { event ->
             when (event) {
-                ScrollToTop -> coroutineScope.launch { lazyListState.scrollToItem(0) }
+                ScrollToTop -> lazyListState.scrollToItem(0)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Remove redundant coroutine launch when handling scroll-to-top events in Explore UI

## Testing
- `./gradlew test` *(fails: local.properties not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5758ae0b0832e83b6cb946a6d04fb