### PR TITLE
Fix progress indicator width in Compose lists

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiContent.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiContent.kt
@@ -150,6 +150,6 @@ private fun FillMaxWidthProgressIndicator(
     ProgressIndicator(
         modifier = Modifier
             .padding(padding)
-            .fillMaxSize(),
+            .fillMaxWidth(),
     )
 }

--- a/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiContent.kt
+++ b/presentation/favourites/src/main/kotlin/com/sottti/roller/coasters/presentation/favourites/ui/FavouritesUiContent.kt
@@ -132,7 +132,7 @@ private fun RollerCoaster(
     rollerCoaster: FavouritesRollerCoaster,
 ) {
     RollerCoasterCard.Small(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxWidth(),
         onClick = { onNavigateToRollerCoaster(rollerCoaster.id) },
         imageUrl = rollerCoaster.imageUrl,
         parkName = rollerCoaster.parkName,
@@ -147,6 +147,6 @@ private fun FillMaxWidthProgressIndicator(
     ProgressIndicator(
         modifier = Modifier
             .padding(padding)
-            .fillMaxSize(),
+            .fillMaxWidth(),
     )
 }


### PR DESCRIPTION
## Summary
- Avoid stretching roller coaster card items to fill the entire height
- Use fillMaxWidth for progress indicators in list footers

## Testing
- `./gradlew build` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b575953690832e9145c92171cc467c