### PR TITLE
refactor: remember top bar colors

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
@@ -23,8 +23,9 @@ internal fun ExploreTopBar(
     onAction: (ExploreAction) -> Unit,
     onNavigateToSettings: () -> Unit,
 ) {
-    val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
-    val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
+    val topAppBarColors = remember { TopAppBarDefaults.topAppBarColors() }
+    val containerColor = topAppBarColors.containerColor
+    val scrolledContainerColor = topAppBarColors.scrolledContainerColor
     val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
@@ -27,8 +27,9 @@ internal fun SearchTopBar(
     onNavigateToSettings: () -> Unit,
     state: SearchState,
 ) {
-    val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
-    val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
+    val topAppBarColors = remember { TopAppBarDefaults.topAppBarColors() }
+    val containerColor = topAppBarColors.containerColor
+    val scrolledContainerColor = topAppBarColors.scrolledContainerColor
     val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,


### PR DESCRIPTION
## Summary
- avoid redundant creation of top app bar colors by remembering them in ExploreTopBar and SearchTopBar

## Testing
- `./gradlew :presentation:explore:test :presentation:search:test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b575a9acd0832eb12b0f74f691a388