### PR TITLE
Remove unnecessary Compose optimizations

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiFilterChips.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiFilterChips.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.design.system.chip.Chip
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
@@ -25,11 +24,10 @@ internal fun FilterChips(
     filters: Filters,
     onAction: (ExploreAction) -> Unit,
 ) {
-    val rememberedOnAction = rememberUpdatedState(onAction)
     Column(modifier = Modifier.padding(vertical = dimensions.padding.small)) {
-        PrimaryFilters(filters.primary, rememberedOnAction.value)
+        PrimaryFilters(filters.primary, onAction)
         Spacer(dimensions.padding.small)
-        SecondaryFilters(filters.secondary, rememberedOnAction.value)
+        SecondaryFilters(filters.secondary, onAction)
     }
 }
 

--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.explore.model.ExploreAction
 import com.sottti.roller.coasters.presentation.explore.model.Filters
@@ -25,7 +23,7 @@ internal fun ExploreTopBar(
 ) {
     val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
     val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
-    val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
+    val isScrolled = lazyListState.firstVisibleItemScrollOffset > 0
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,
         label = "expandable top bar background color animation",

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -53,17 +52,14 @@ internal fun RollerCoasterDetailsUi(
     onBackNavigation: () -> Unit,
     state: RollerCoasterDetailsState,
 ) {
-    val content = remember(state.content) { state.content }
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val topBarState = remember(state.topBar) { state.topBar }
-    val onToggleFavourite = remember(onAction) { { onAction(ToggleFavourite) } }
 
     RollerCoasterDetailsContent(
-        content = content,
+        content = state.content,
         onBackNavigation = onBackNavigation,
-        onToggleFavourite = onToggleFavourite,
+        onToggleFavourite = { onAction(ToggleFavourite) },
         scrollBehavior = scrollBehavior,
-        topBarState = topBarState,
+        topBarState = state.topBar,
     )
 }
 

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiContent.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiContent.kt
@@ -163,7 +163,7 @@ private fun DetailsSection(
 
 @Composable
 private fun RideDetails(details: RollerCoasterRideState) {
-    val items = remember(
+    val items = listOfNotNull(
         details.speed,
         details.height,
         details.drop,
@@ -172,18 +172,7 @@ private fun RideDetails(details: RollerCoasterRideState) {
         details.length,
         details.duration,
         details.gForce,
-    ) {
-        listOfNotNull(
-            details.speed,
-            details.height,
-            details.drop,
-            details.maxVertical,
-            details.inversions,
-            details.length,
-            details.duration,
-            details.gForce,
-        )
-    }
+    )
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -194,9 +183,7 @@ private fun RideDetails(details: RollerCoasterRideState) {
 
 @Composable
 private fun IdentityDetails(state: RollerCoasterIdentityState) {
-    val items = remember(state.name, state.formerNames) {
-        listOfNotNull(state.name, state.formerNames)
-    }
+    val items = listOfNotNull(state.name, state.formerNames)
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -207,14 +194,7 @@ private fun IdentityDetails(state: RollerCoasterIdentityState) {
 
 @Composable
 private fun StatusDetails(state: RollerCoasterStatusState) {
-    val items = remember(
-        state.current,
-        state.former,
-        state.openedDate,
-        state.closedDate,
-    ) {
-        listOfNotNull(state.current, state.former, state.openedDate, state.closedDate)
-    }
+    val items = listOfNotNull(state.current, state.former, state.openedDate, state.closedDate)
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -238,9 +218,7 @@ private fun LocationDetails(state: RollerCoasterLocationState) {
             )
         }
 
-        val items = remember(state.park, state.city, state.country, state.relocations) {
-            listOfNotNull(state.park, state.city, state.country, state.relocations)
-        }
+        val items = listOfNotNull(state.park, state.city, state.country, state.relocations)
         items.forEachIndexed { index, item ->
             ListItem(state = item, showBottomDivider = index < items.lastIndex)
         }

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
 import com.sottti.roller.coasters.presentation.design.system.search.box.SearchBox
@@ -29,7 +27,7 @@ internal fun SearchTopBar(
 ) {
     val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
     val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
-    val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
+    val isScrolled = lazyListState.firstVisibleItemScrollOffset > 0
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,
         label = "expandable top bar background color animation",

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiList.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiList.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -46,20 +45,20 @@ internal fun SettingsList(
     state: SettingsState,
     onAction: (SettingsAction) -> Unit,
 ) {
-    val onDynamicColorCheckedChange = remember(onAction) {
-        { checked: Boolean -> onAction(DynamicColorCheckedChange(checked)) }
+    val onDynamicColorCheckedChange: (Boolean) -> Unit = { checked ->
+        onAction(DynamicColorCheckedChange(checked))
     }
-    val launchThemePicker = remember(onAction) {
-        { onAction(LaunchAppThemePicker) }
+    val launchThemePicker = {
+        onAction(LaunchAppThemePicker)
     }
-    val launchColorContrastPicker = remember(onAction) {
-        { onAction(LaunchAppColorContrastPicker) }
+    val launchColorContrastPicker = {
+        onAction(LaunchAppColorContrastPicker)
     }
-    val launchLanguagePicker = remember(onAction) {
-        { onAction(LaunchAppLanguagePicker) }
+    val launchLanguagePicker = {
+        onAction(LaunchAppLanguagePicker)
     }
-    val launchMeasurementSystemPicker = remember(onAction) {
-        { onAction(AppMeasurementSystemActions.LaunchAppMeasurementSystemPicker) }
+    val launchMeasurementSystemPicker = {
+        onAction(AppMeasurementSystemActions.LaunchAppMeasurementSystemPicker)
     }
     LazyColumn(
         contentPadding = padding + PaddingValues(vertical = dimensions.padding.medium),


### PR DESCRIPTION
## Summary
- simplify RollerCoasterDetails screen by using state directly
- drop scroll tracking optimizations in Explore/Search top bars
- remove redundant remember calls across filter chips and settings list

## Testing
- `./gradlew test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b575b6ce40832ebad47ae01e8d432d