### PR TITLE
Remove unneeded remember optimizations

### DIFF
--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiFilterChips.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiFilterChips.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.key
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.design.system.chip.Chip
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
@@ -25,11 +24,10 @@ internal fun FilterChips(
     filters: Filters,
     onAction: (ExploreAction) -> Unit,
 ) {
-    val rememberedOnAction = rememberUpdatedState(onAction)
     Column(modifier = Modifier.padding(vertical = dimensions.padding.small)) {
-        PrimaryFilters(filters.primary, rememberedOnAction.value)
+        PrimaryFilters(filters.primary, onAction)
         Spacer(dimensions.padding.small)
-        SecondaryFilters(filters.secondary, rememberedOnAction.value)
+        SecondaryFilters(filters.secondary, onAction)
     }
 }
 

--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
@@ -21,8 +21,9 @@ internal fun ExploreTopBar(
     onAction: (ExploreAction) -> Unit,
     onNavigateToSettings: () -> Unit,
 ) {
-    val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
-    val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
+    val topBarColors = TopAppBarDefaults.topAppBarColors()
+    val containerColor = topBarColors.containerColor
+    val scrolledContainerColor = topBarColors.scrolledContainerColor
     val isScrolled = lazyListState.firstVisibleItemScrollOffset > 0
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,

--- a/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
+++ b/presentation/explore/src/main/kotlin/com/sottti/roller/coasters/presentation/explore/ui/ExploreUiTopBar.kt
@@ -7,9 +7,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.explore.model.ExploreAction
 import com.sottti.roller.coasters.presentation.explore.model.Filters
@@ -25,7 +23,7 @@ internal fun ExploreTopBar(
 ) {
     val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
     val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
-    val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
+    val isScrolled = lazyListState.firstVisibleItemScrollOffset > 0
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,
         label = "expandable top bar background color animation",

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUi.kt
@@ -5,7 +5,6 @@ import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -53,10 +52,10 @@ internal fun RollerCoasterDetailsUi(
     onBackNavigation: () -> Unit,
     state: RollerCoasterDetailsState,
 ) {
-    val content = remember(state.content) { state.content }
+    val content = state.content
     val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-    val topBarState = remember(state.topBar) { state.topBar }
-    val onToggleFavourite = remember(onAction) { { onAction(ToggleFavourite) } }
+    val topBarState = state.topBar
+    val onToggleFavourite = { onAction(ToggleFavourite) }
 
     RollerCoasterDetailsContent(
         content = content,

--- a/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiContent.kt
+++ b/presentation/roller-coaster-details/src/main/kotlin/com/sottti/roller/coasters/presentation/roller/coaster/details/ui/RollerCoasterDetailsUiContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -124,7 +123,7 @@ private fun ImagesSection(
     val density = LocalDensity.current
     val windowHeightPx = LocalWindowInfo.current.containerSize.height
     val windowHeightDp = with(density) { windowHeightPx.toDp() }
-    val carouselHeight = remember(windowHeightDp) { (windowHeightDp * 0.25f) }
+    val carouselHeight = windowHeightDp * 0.25f
 
     Column(Modifier.fillMaxWidth()) {
         HorizontalPager(
@@ -163,7 +162,7 @@ private fun DetailsSection(
 
 @Composable
 private fun RideDetails(details: RollerCoasterRideState) {
-    val items = remember(
+    val items = listOfNotNull(
         details.speed,
         details.height,
         details.drop,
@@ -172,18 +171,7 @@ private fun RideDetails(details: RollerCoasterRideState) {
         details.length,
         details.duration,
         details.gForce,
-    ) {
-        listOfNotNull(
-            details.speed,
-            details.height,
-            details.drop,
-            details.maxVertical,
-            details.inversions,
-            details.length,
-            details.duration,
-            details.gForce,
-        )
-    }
+    )
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -194,9 +182,7 @@ private fun RideDetails(details: RollerCoasterRideState) {
 
 @Composable
 private fun IdentityDetails(state: RollerCoasterIdentityState) {
-    val items = remember(state.name, state.formerNames) {
-        listOfNotNull(state.name, state.formerNames)
-    }
+    val items = listOfNotNull(state.name, state.formerNames)
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -207,14 +193,7 @@ private fun IdentityDetails(state: RollerCoasterIdentityState) {
 
 @Composable
 private fun StatusDetails(state: RollerCoasterStatusState) {
-    val items = remember(
-        state.current,
-        state.former,
-        state.openedDate,
-        state.closedDate,
-    ) {
-        listOfNotNull(state.current, state.former, state.openedDate, state.closedDate)
-    }
+    val items = listOfNotNull(state.current, state.former, state.openedDate, state.closedDate)
 
     DetailsCard {
         items.forEachIndexed { index, item ->
@@ -238,9 +217,7 @@ private fun LocationDetails(state: RollerCoasterLocationState) {
             )
         }
 
-        val items = remember(state.park, state.city, state.country, state.relocations) {
-            listOfNotNull(state.park, state.city, state.country, state.relocations)
-        }
+        val items = listOfNotNull(state.park, state.city, state.country, state.relocations)
         items.forEachIndexed { index, item ->
             ListItem(state = item, showBottomDivider = index < items.lastIndex)
         }

--- a/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
+++ b/presentation/search/src/main/kotlin/com/sottti/roller/coasters/presentation/search/ui/SearchUiTopBar.kt
@@ -9,9 +9,7 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
 import com.sottti.roller.coasters.presentation.design.system.search.box.SearchBox
@@ -29,7 +27,7 @@ internal fun SearchTopBar(
 ) {
     val containerColor = TopAppBarDefaults.topAppBarColors().containerColor
     val scrolledContainerColor = TopAppBarDefaults.topAppBarColors().scrolledContainerColor
-    val isScrolled by remember { derivedStateOf { lazyListState.firstVisibleItemScrollOffset > 0 } }
+    val isScrolled = lazyListState.firstVisibleItemScrollOffset > 0
     val backgroundColor by animateColorAsState(
         targetValue = if (isScrolled) scrolledContainerColor else containerColor,
         label = "expandable top bar background color animation",

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiList.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiList.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.ListItemDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
@@ -46,20 +45,14 @@ internal fun SettingsList(
     state: SettingsState,
     onAction: (SettingsAction) -> Unit,
 ) {
-    val onDynamicColorCheckedChange = remember(onAction) {
-        { checked: Boolean -> onAction(DynamicColorCheckedChange(checked)) }
+    val onDynamicColorCheckedChange: (Boolean) -> Unit = {
+        onAction(DynamicColorCheckedChange(it))
     }
-    val launchThemePicker = remember(onAction) {
-        { onAction(LaunchAppThemePicker) }
-    }
-    val launchColorContrastPicker = remember(onAction) {
-        { onAction(LaunchAppColorContrastPicker) }
-    }
-    val launchLanguagePicker = remember(onAction) {
-        { onAction(LaunchAppLanguagePicker) }
-    }
-    val launchMeasurementSystemPicker = remember(onAction) {
-        { onAction(AppMeasurementSystemActions.LaunchAppMeasurementSystemPicker) }
+    val launchThemePicker = { onAction(LaunchAppThemePicker) }
+    val launchColorContrastPicker = { onAction(LaunchAppColorContrastPicker) }
+    val launchLanguagePicker = { onAction(LaunchAppLanguagePicker) }
+    val launchMeasurementSystemPicker = {
+        onAction(AppMeasurementSystemActions.LaunchAppMeasurementSystemPicker)
     }
     LazyColumn(
         contentPadding = padding + PaddingValues(vertical = dimensions.padding.medium),

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/SettingsUiTopBar.kt
@@ -4,8 +4,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberUpdatedState
 import com.sottti.roller.coasters.presentation.design.system.icons.ui.icon.Icon
 import com.sottti.roller.coasters.presentation.design.system.text.Text
 import com.sottti.roller.coasters.presentation.settings.model.SettingsTopBarState
@@ -29,9 +27,8 @@ private fun NavigationIcon(
     state: SettingsTopBarState,
     onBackNavigation: () -> Unit,
 ) {
-    val currentOnBack by rememberUpdatedState(onBackNavigation)
     Icon(
         iconState = state.icon,
-        onClick = { currentOnBack() },
+        onClick = onBackNavigation,
     )
 }

--- a/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/dialogs/SettingsUiGenericPickerDialog.kt
+++ b/presentation/settings/src/main/kotlin/com/sottti/roller/coasters/presentation/settings/ui/dialogs/SettingsUiGenericPickerDialog.kt
@@ -1,9 +1,6 @@
 package com.sottti.roller.coasters.presentation.settings.ui.dialogs
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import com.sottti.roller.coasters.presentation.design.system.dialogs.radioButtons.DialogRadioButtonOption
 import com.sottti.roller.coasters.presentation.design.system.dialogs.radioButtons.DialogWithRadioButtons
 
@@ -20,24 +17,13 @@ internal fun <T> GenericPickerDialog(
     onConfirm: (T) -> Unit,
     onDismiss: () -> Unit,
 ) {
-    val options = remember(items) {
-        items.map(toOption)
+    val options = items.map(toOption)
+    val selectedItem = findSelected(items)
+    val onOptionSelected: (DialogRadioButtonOption) -> Unit = { opt ->
+        val itm = fromOption(opt, items)
+        onSelect(itm)
     }
-    val selectedItem = remember(items) {
-        findSelected(items)
-    }
-    val currentOnSelect by rememberUpdatedState(onSelect)
-    val onOptionSelected = remember(currentOnSelect, items) {
-        { opt: DialogRadioButtonOption ->
-            val itm = fromOption(opt, items)
-            currentOnSelect(itm)
-        }
-    }
-    val onConfirmAction = remember(onConfirm, selectedItem) {
-        { onConfirm(selectedItem) }
-    }
-    val currentOnDismiss by rememberUpdatedState(onDismiss)
-    val onDismissAction = remember { { currentOnDismiss() } }
+    val onConfirmAction = { onConfirm(selectedItem) }
 
     DialogWithRadioButtons(
         title = title,
@@ -46,7 +32,7 @@ internal fun <T> GenericPickerDialog(
         dismiss = dismiss,
         onOptionSelected = onOptionSelected,
         onConfirm = onConfirmAction,
-        onDismiss = onDismissAction,
+        onDismiss = onDismiss,
     )
 }
 


### PR DESCRIPTION
## Summary
- inline RollerCoaster details state and callbacks instead of remembering them
- drop remembered computations in details content and top bars
- simplify settings helpers by removing `rememberUpdatedState` and other `remember` wrappers

## Testing
- `./gradlew test` *(fails: Cannot find Java installation matching {languageVersion=17}))*

------
https://chatgpt.com/codex/tasks/task_e_68b575d7d484832e9eb3e34a164897ce