### PR TITLE
Use AGP built-in Kotlin support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,6 @@ import com.sottti.roller.coasters.buildSrc.module
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.secrets)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     alias(libs.plugins.dependency.analysis) apply false
     alias(libs.plugins.dependency.versions) apply true
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.ksp) apply false

--- a/data/features/build.gradle.kts
+++ b/data/features/build.gradle.kts
@@ -3,7 +3,6 @@ import com.sottti.roller.coasters.buildSrc.module
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/data/network/build.gradle.kts
+++ b/data/network/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.serialization)
 }

--- a/data/roller-coasters/build.gradle.kts
+++ b/data/roller-coasters/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.kotlin.serialization)
 }

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/di/build.gradle.kts
+++ b/di/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,3 +24,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+
+android.builtInKotlin=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,7 +103,6 @@ build-health = { id = "com.autonomousapps.build-health", version.ref = "build-he
 dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 dependency-versions = { id = "com.github.ben-manes.versions", version.ref = "dependency-versions" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "kotlin-ksp" }

--- a/presentation/about-me/build.gradle.kts
+++ b/presentation/about-me/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/design-system/card-grid/build.gradle.kts
+++ b/presentation/design-system/card-grid/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/chip/build.gradle.kts
+++ b/presentation/design-system/chip/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/colors/build.gradle.kts
+++ b/presentation/design-system/colors/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/design-system/dialogs/build.gradle.kts
+++ b/presentation/design-system/dialogs/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/dimensions/build.gradle.kts
+++ b/presentation/design-system/dimensions/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/design-system/hero-image/build.gradle.kts
+++ b/presentation/design-system/hero-image/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/icons/build.gradle.kts
+++ b/presentation/design-system/icons/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/illustrations/build.gradle.kts
+++ b/presentation/design-system/illustrations/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/images/build.gradle.kts
+++ b/presentation/design-system/images/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/map/build.gradle.kts
+++ b/presentation/design-system/map/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/playground/build.gradle.kts
+++ b/presentation/design-system/playground/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/design-system/progress-indicators/build.gradle.kts
+++ b/presentation/design-system/progress-indicators/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/roller-coaster-card/build.gradle.kts
+++ b/presentation/design-system/roller-coaster-card/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/search-box/build.gradle.kts
+++ b/presentation/design-system/search-box/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/switch/build.gradle.kts
+++ b/presentation/design-system/switch/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/text/build.gradle.kts
+++ b/presentation/design-system/text/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/design-system/themes/build.gradle.kts
+++ b/presentation/design-system/themes/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/design-system/typography/build.gradle.kts
+++ b/presentation/design-system/typography/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/empty/build.gradle.kts
+++ b/presentation/empty/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/error/build.gradle.kts
+++ b/presentation/error/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/explore/build.gradle.kts
+++ b/presentation/explore/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/favourites/build.gradle.kts
+++ b/presentation/favourites/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/fixtures/build.gradle.kts
+++ b/presentation/fixtures/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/format/build.gradle.kts
+++ b/presentation/format/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
 }

--- a/presentation/home/build.gradle.kts
+++ b/presentation/home/build.gradle.kts
@@ -3,7 +3,6 @@ import com.sottti.roller.coasters.buildSrc.module
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/image-loading/build.gradle.kts
+++ b/presentation/image-loading/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/informative/build.gradle.kts
+++ b/presentation/informative/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/navigation-external/build.gradle.kts
+++ b/presentation/navigation-external/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/presentation/navigation/build.gradle.kts
+++ b/presentation/navigation/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
 }

--- a/presentation/previews/build.gradle.kts
+++ b/presentation/previews/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 

--- a/presentation/roller-coaster-details/build.gradle.kts
+++ b/presentation/roller-coaster-details/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/search/build.gradle.kts
+++ b/presentation/search/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/settings/build.gradle.kts
+++ b/presentation/settings/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.ksp)
     alias(libs.plugins.paparazzi)

--- a/presentation/string-provider/build.gradle.kts
+++ b/presentation/string-provider/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.ksp)
 }
 

--- a/presentation/top-bars/build.gradle.kts
+++ b/presentation/top-bars/build.gradle.kts
@@ -2,7 +2,6 @@ import com.sottti.roller.coasters.buildSrc.module
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.paparazzi)
 }

--- a/presentation/utils/build.gradle.kts
+++ b/presentation/utils/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
 }
 


### PR DESCRIPTION
## Summary
- enable AGP's built-in Kotlin support
- drop explicit `kotlin-android` plugin usage across modules

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68b58bf1650c832eb6ec13d0fbf77ece