### PR TITLE
Improve backup rules formatting

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Applies on Android 6.0–11 (API 23–30). Keep because minSdk is 26. -->
-<full-backup-content>
+<full-backup-content xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Back up all SharedPreferences -->
     <include domain="sharedpref" path="."/>
     <!-- Back up all app databases -->

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Minimal, safe defaults for Android 12+ (API 31+) -->
-<data-extraction-rules>
+<data-extraction-rules xmlns:android="http://schemas.android.com/apk/res/android">
     <!-- Cloud backup to Google Drive -->
     <cloud-backup>
         <!-- Back up all SharedPreferences -->


### PR DESCRIPTION
## Summary
- add explicit Android namespace to backup rule XML files
- ensure backup configuration XML files end with newline for proper formatting

## Testing
- `./gradlew test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*
- `./gradlew :app:test` *(fails: The file '/workspace/RollerCoasters/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_68b985a91920832eb9c048e0fe417b2a