### PR TITLE
Annotate read-only composables in design system

### DIFF
--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/CornerRadiiTokens.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/CornerRadiiTokens.kt
@@ -2,10 +2,12 @@ package com.sottti.roller.coasters.presentation.design.system.dimensions.tokens
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.CornerRadii
 
 internal object CornerRadiiTokens {
     @Composable
+    @ReadOnlyComposable
     internal fun compact(): CornerRadii =
         CornerRadii(
             extraSmall = MaterialTheme.shapes.extraSmall,
@@ -16,6 +18,7 @@ internal object CornerRadiiTokens {
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun medium(): CornerRadii =
         CornerRadii(
             extraSmall = MaterialTheme.shapes.extraSmall,
@@ -26,6 +29,7 @@ internal object CornerRadiiTokens {
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun expanded(): CornerRadii =
         CornerRadii(
             extraSmall = MaterialTheme.shapes.extraSmall,

--- a/presentation/design-system/shapes/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/shapes/ShapesFactory.kt
+++ b/presentation/design-system/shapes/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/shapes/ShapesFactory.kt
@@ -1,9 +1,11 @@
 package com.sottti.roller.coasters.presentation.design.system.shapes
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import com.sottti.roller.coasters.presentation.design.system.dimensions.dimensions
 
 @Composable
+@ReadOnlyComposable
 internal fun shapes(): Shapes {
     return Shapes(
         roundedCorner = RoundedCornerShapes(


### PR DESCRIPTION
## Summary
- add `@ReadOnlyComposable` to the shape factory so it is treated as a read-only composition lookup
- mark corner radii token providers as read-only composables when reading `MaterialTheme`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4e1daea14832e9fcb88887581b02a