### PR TITLE
Add missing ReadOnlyComposable annotations

### DIFF
--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsMock.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsMock.kt
@@ -2,12 +2,14 @@ package com.sottti.roller.coasters.presentation.design.system.dimensions
 
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.Dimensions
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.compactDimensions
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.expandedDimensions
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.mediumDimensions
 
 @Composable
+@ReadOnlyComposable
 internal fun mockDimensions(
     windowWidthSizeClass: WindowWidthSizeClass,
 ): Dimensions {

--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/DesignComponentTokens.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/DesignComponentTokens.kt
@@ -1,22 +1,26 @@
 package com.sottti.roller.coasters.presentation.design.system.dimensions.tokens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.ComponentDimensions
 
 internal object DesignComponentTokens {
     @Composable
+    @ReadOnlyComposable
     internal fun compact() =
         ComponentDimensions(
             progressIndicator = ProgressIndicatorTokens.compat(),
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun medium() =
         ComponentDimensions(
             progressIndicator = ProgressIndicatorTokens.medium(),
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun expanded() =
         ComponentDimensions(
             progressIndicator = ProgressIndicatorTokens.expanded(),

--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/DimensionTokens.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/DimensionTokens.kt
@@ -1,9 +1,11 @@
 package com.sottti.roller.coasters.presentation.design.system.dimensions.tokens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.Dimensions
 
 @Composable
+@ReadOnlyComposable
 internal fun compactDimensions() =
     Dimensions(
         component = DesignComponentTokens.compact(),
@@ -12,6 +14,7 @@ internal fun compactDimensions() =
     )
 
 @Composable
+@ReadOnlyComposable
 internal fun mediumDimensions() =
     Dimensions(
         component = DesignComponentTokens.medium(),
@@ -20,6 +23,7 @@ internal fun mediumDimensions() =
     )
 
 @Composable
+@ReadOnlyComposable
 internal fun expandedDimensions() =
     Dimensions(
         component = DesignComponentTokens.expanded(),

--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/ProgressIndicatorTokens.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/ProgressIndicatorTokens.kt
@@ -1,11 +1,13 @@
 package com.sottti.roller.coasters.presentation.design.system.dimensions.tokens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.unit.dp
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.ProgressIndicatorDimensions
 
 internal object ProgressIndicatorTokens {
     @Composable
+    @ReadOnlyComposable
     internal fun compat(): ProgressIndicatorDimensions =
         ProgressIndicatorDimensions(
             small = 24.dp,
@@ -14,6 +16,7 @@ internal object ProgressIndicatorTokens {
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun medium(): ProgressIndicatorDimensions =
         ProgressIndicatorDimensions(
             small = 24.dp,
@@ -23,6 +26,7 @@ internal object ProgressIndicatorTokens {
 
 
     @Composable
+    @ReadOnlyComposable
     internal fun expanded(): ProgressIndicatorDimensions =
         ProgressIndicatorDimensions(
             small = 24.dp,

--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/SpacingTokens.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/tokens/SpacingTokens.kt
@@ -1,11 +1,13 @@
 package com.sottti.roller.coasters.presentation.design.system.dimensions.tokens
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.unit.dp
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.Spacing
 
 internal object SpacingTokens {
     @Composable
+    @ReadOnlyComposable
     internal fun compact(): Spacing =
         Spacing(
             none = 0.dp,
@@ -19,6 +21,7 @@ internal object SpacingTokens {
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun medium(): Spacing =
         Spacing(
             none = 0.dp,
@@ -32,6 +35,7 @@ internal object SpacingTokens {
         )
 
     @Composable
+    @ReadOnlyComposable
     internal fun expanded(): Spacing =
         Spacing(
             none = 0.dp,

--- a/presentation/design-system/typography/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/typography/TypographyFactory.kt
+++ b/presentation/design-system/typography/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/typography/TypographyFactory.kt
@@ -1,9 +1,11 @@
 package com.sottti.roller.coasters.presentation.design.system.typography
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.material3.Typography as MaterialTypography
 
 @Composable
+@ReadOnlyComposable
 internal fun typography(): Typography =
     with(MaterialTypography()) {
         Typography(


### PR DESCRIPTION
## Summary
- annotate dimension token factories with @ReadOnlyComposable to mark them as pure reads
- mark mockDimensions and typography factory as read-only composables for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4ebc1a0e0832e9af2a46c66ada03c