### PR TITLE
Annotate dimensions factory with ReadOnlyComposable

### DIFF
--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsFactory.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsFactory.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalContext
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.Dimensions
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.compactDimensions
@@ -12,6 +13,7 @@ import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.e
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.mediumDimensions
 
 @Composable
+@ReadOnlyComposable
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
 internal fun dimensions(): Dimensions {
     val windowSizeClass = calculateWindowSizeClass(LocalContext.current as Activity)


### PR DESCRIPTION
## Summary
- mark the design system dimensions factory as @ReadOnlyComposable to ensure it can be safely called from other read-only composables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f1284358832eb84aca662d023e89