### PR TITLE
Add missing @ReadOnlyComposable annotations

### DIFF
--- a/presentation/design-system/search-bar/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/search/bar/SearchBar.kt
+++ b/presentation/design-system/search-bar/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/search/bar/SearchBar.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -43,6 +44,7 @@ public fun SearchBar(
 }
 
 @Composable
+@ReadOnlyComposable
 private fun searchBarColors() = TextFieldDefaults.colors(
     unfocusedIndicatorColor = Color.Transparent,
     focusedIndicatorColor = Color.Transparent,

--- a/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/Image.kt
+++ b/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/Image.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -85,6 +86,7 @@ private fun imageRequest(url: ImageUrl): ImageRequest {
 }
 
 @Composable
+@ReadOnlyComposable
 private fun previewImageModel() = R.drawable.dragon_khan_hero_image
 
 @Composable


### PR DESCRIPTION
## Summary
- annotate the preview image helper as read-only to better signal state usage
- mark the search bar color defaults helper as read-only

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e4f129abf4832ea248d0d96d4bf3a2