### PR TITLE
Add missing ReadOnlyComposable annotations

### DIFF
--- a/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsFactory.kt
+++ b/presentation/design-system/dimensions/src/main/kotlin/com/sottti/roller/coasters/presentation/design/system/dimensions/DimensionsFactory.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSiz
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.platform.LocalContext
 import com.sottti.roller.coasters.presentation.design.system.dimensions.model.Dimensions
 import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.compactDimensions
@@ -13,6 +14,7 @@ import com.sottti.roller.coasters.presentation.design.system.dimensions.tokens.m
 
 @Composable
 @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
+@ReadOnlyComposable
 internal fun dimensions(): Dimensions {
     val windowSizeClass = calculateWindowSizeClass(LocalContext.current as Activity)
     return when (windowSizeClass.widthSizeClass) {

--- a/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/Image.kt
+++ b/presentation/image-loading/src/main/kotlin/com/sottti/roller/coasters/presentation/image/loading/Image.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.shape.ZeroCornerSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -73,6 +74,7 @@ private fun PlaceHolder(
 }
 
 @Composable
+@ReadOnlyComposable
 private fun imageRequest(url: ImageUrl): ImageRequest {
     val context = LocalContext.current
     return remember(url, context) {


### PR DESCRIPTION
## Summary
- annotate the dimensions factory helper with `@ReadOnlyComposable`
- mark the image request helper as read-only when reading from composition locals

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4f12b94c0832e8e9b26e10f487878