### PR TITLE
Remove extra blank lines after namespace declarations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.app"
-
     androidResources {
         @Suppress("UnstableApiUsage")
         generateLocaleConfig = true

--- a/data/settings/build.gradle.kts
+++ b/data/settings/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.data.settings"
-
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/design-system/chip/build.gradle.kts
+++ b/presentation/design-system/chip/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.chip"
-
 }
 
 dependencies {

--- a/presentation/design-system/dialogs/build.gradle.kts
+++ b/presentation/design-system/dialogs/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.dialogs"
-
 }
 
 dependencies {

--- a/presentation/design-system/dimensions/build.gradle.kts
+++ b/presentation/design-system/dimensions/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.dimensions"
-
 }
 
 dependencies {

--- a/presentation/design-system/empty/build.gradle.kts
+++ b/presentation/design-system/empty/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.empty"
-
 }
 
 dependencies {

--- a/presentation/design-system/error/build.gradle.kts
+++ b/presentation/design-system/error/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.error"
-
 }
 
 dependencies {

--- a/presentation/design-system/hero-image/build.gradle.kts
+++ b/presentation/design-system/hero-image/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.hero.image"
-
 }
 
 dependencies {

--- a/presentation/design-system/icon-resources/build.gradle.kts
+++ b/presentation/design-system/icon-resources/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.icon.resources"
-
 }
 
 dependencies {

--- a/presentation/design-system/illustrations/build.gradle.kts
+++ b/presentation/design-system/illustrations/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.illustrations"
-
 }
 
 dependencies {

--- a/presentation/design-system/images/build.gradle.kts
+++ b/presentation/design-system/images/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.images"
-
 }
 
 dependencies {

--- a/presentation/design-system/informative/build.gradle.kts
+++ b/presentation/design-system/informative/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.informative"
-
 }
 
 dependencies {

--- a/presentation/design-system/map/build.gradle.kts
+++ b/presentation/design-system/map/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.map"
-
 }
 
 dependencies {

--- a/presentation/design-system/playground/build.gradle.kts
+++ b/presentation/design-system/playground/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.playground"
-
 }
 
 dependencies {

--- a/presentation/design-system/progress-indicators/build.gradle.kts
+++ b/presentation/design-system/progress-indicators/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.progress.indicators"
-
 }
 
 dependencies {

--- a/presentation/design-system/roller-coaster-card/build.gradle.kts
+++ b/presentation/design-system/roller-coaster-card/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.roller.coaster.card"
-
 }
 
 dependencies {

--- a/presentation/design-system/search-bar/build.gradle.kts
+++ b/presentation/design-system/search-bar/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.search.bar"
-
 }
 
 dependencies {

--- a/presentation/design-system/shapes/build.gradle.kts
+++ b/presentation/design-system/shapes/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.shapes"
-
 }
 
 dependencies {

--- a/presentation/design-system/switch/build.gradle.kts
+++ b/presentation/design-system/switch/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.switchh"
-
 }
 
 dependencies {

--- a/presentation/design-system/text/build.gradle.kts
+++ b/presentation/design-system/text/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.text"
-
 }
 
 dependencies {

--- a/presentation/design-system/typography/build.gradle.kts
+++ b/presentation/design-system/typography/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.design.system.typography"
-
 }
 
 dependencies {

--- a/presentation/explore/build.gradle.kts
+++ b/presentation/explore/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.explore"
-
 }
 
 dependencies {

--- a/presentation/favourites/build.gradle.kts
+++ b/presentation/favourites/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.favourites"
-
 }
 
 dependencies {

--- a/presentation/fixtures/build.gradle.kts
+++ b/presentation/fixtures/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.fixtures"
-
 }
 
 dependencies {

--- a/presentation/format/build.gradle.kts
+++ b/presentation/format/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.format"
-
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/presentation/image-loading/build.gradle.kts
+++ b/presentation/image-loading/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.image.loading"
-
 }
 
 dependencies {

--- a/presentation/previews/build.gradle.kts
+++ b/presentation/previews/build.gradle.kts
@@ -6,7 +6,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.previews"
-
 }
 
 dependencies {

--- a/presentation/search/build.gradle.kts
+++ b/presentation/search/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.search"
-
 }
 
 dependencies {

--- a/presentation/top-bars/build.gradle.kts
+++ b/presentation/top-bars/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
 
 android {
     namespace = "com.sottti.roller.coasters.presentation.top.bars"
-
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- remove the blank line that followed the namespace declaration in each android block so the closing brace or next section appears immediately afterwards

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fc8e128060832e9f7afd27e35a5ceb