### PR TITLE
Remove unused Android Startup dependency

### DIFF
--- a/data/roller-coasters/build.gradle.kts
+++ b/data/roller-coasters/build.gradle.kts
@@ -18,7 +18,6 @@ dependencies {
     implementation(libs.paging.runtime)
     implementation(libs.room)
     implementation(libs.room.paging)
-    implementation(libs.startup.runtime)
     implementation(libs.work.runtime)
     implementation(project(module.data.network))
     implementation(project(module.domain.fixtures))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ result = "2.1.0"
 room = "2.8.2"
 secrets = "2.0.1"
 splashscreen = "1.2.0-rc01"
-startup = "1.2.0"
 targetSdk = "36"
 test-runner = "1.7.0"
 truth = "1.4.5"
@@ -93,7 +92,6 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
 room-testing = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
-startup-runtime = { group = "androidx.startup", name = "startup-runtime", version.ref = "startup" }
 test-runner = { group = "androidx.test", name = "runner", version.ref = "test-runner" }
 truth = { group = "com.google.truth", name = "truth", version.ref = "truth" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }

--- a/presentation/image-loading/build.gradle.kts
+++ b/presentation/image-loading/build.gradle.kts
@@ -22,6 +22,5 @@ dependencies {
     implementation(project(module.presentation.designSystem.themes))
     implementation(project(module.presentation.fixtures))
     implementation(project(module.presentation.previews))
-    runtimeOnly(libs.startup.runtime)
     testImplementation(project(module.presentation.paparazzi))
 }


### PR DESCRIPTION
## Summary
- remove the androidx.startup entry from the version catalog
- drop the unused startup dependency from the data and presentation modules

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fcc7ac5560832ebf8634646aa3f96a